### PR TITLE
Updated package and lockfiles for 2.8.0. No changes to storage key parameters required.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
 			"dependencies": {
 				"@iconify-json/mingcute": "^1.2.7",
 				"@iconify/svelte": "^5.2.1",
-				"@leaningtech/browserpod": "2.6.3",
+				"@leaningtech/browserpod": "2.8.0",
 				"qrcode": "^1.5.4"
 			},
 			"devDependencies": {
@@ -836,9 +836,9 @@
 			}
 		},
 		"node_modules/@leaningtech/browserpod": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/@leaningtech/browserpod/-/browserpod-2.6.3.tgz",
-			"integrity": "sha512-e3zudONiPXrMaVqyQ+gXfs/7sZmvqIbWO9gYIEgB5WYkCkDdtwSLPnT4yz9///dT62/AzFt2VvoLJYdwPW2v1g==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@leaningtech/browserpod/-/browserpod-2.8.0.tgz",
+			"integrity": "sha512-Mt22fQpFfJssIiKhb1HBa9665NLEvCW6tJRXjFTeL5cp4jjEaBKg+Smu2G3Uhe1QFtH6t03ElEPJSPawwqNtTw==",
 			"license": "SEE LICENSE IN LICENSE.txt"
 		},
 		"node_modules/@polka/url": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
 	"dependencies": {
 		"@iconify-json/mingcute": "^1.2.7",
 		"@iconify/svelte": "^5.2.1",
-		"@leaningtech/browserpod": "2.6.3",
+		"@leaningtech/browserpod": "2.8.0",
 		"qrcode": "^1.5.4"
 	}
 }


### PR DESCRIPTION
Updated versions. Fixed storage key already in place, which is correct for use case as any other storage key type would require the user to login on each page load.