### PR TITLE
Boot the playground from a GitHub repo, plus editor features

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
 				"@iconify/svelte": "^5.2.1",
 				"@leaningtech/browserpod": "2.16.0",
 				"@sveltejs/adapter-static": "^3.0.10",
+				"fflate": "^0.8.3",
 				"monaco-editor": "^0.55.1",
 				"qrcode": "^1.5.4"
 			},
@@ -2526,6 +2527,12 @@
 					"optional": true
 				}
 			}
+		},
+		"node_modules/fflate": {
+			"version": "0.8.3",
+			"resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+			"integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+			"license": "MIT"
 		},
 		"node_modules/file-entry-cache": {
 			"version": "8.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
 	"name": "browsercode",
-	"version": "0.6.2",
+	"version": "0.7.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "browsercode",
-			"version": "0.6.2",
+			"version": "0.7.0",
 			"dependencies": {
 				"@iconify-json/mingcute": "^1.2.7",
 				"@iconify/svelte": "^5.2.1",
-				"@leaningtech/browserpod": "2.16.0",
+				"@leaningtech/browserpod": "2.18.0",
 				"@sveltejs/adapter-static": "^3.0.10",
 				"fflate": "^0.8.3",
 				"monaco-editor": "^0.55.1",
@@ -812,9 +812,9 @@
 			}
 		},
 		"node_modules/@leaningtech/browserpod": {
-			"version": "2.16.0",
-			"resolved": "https://registry.npmjs.org/@leaningtech/browserpod/-/browserpod-2.16.0.tgz",
-			"integrity": "sha512-NeGkHVtPRWxTk7JzsZWMqL81ysrHz+KEFhwaLyaEmnb/5YZUfFAzsCztP/Thoc7H3Of2D8y8a+1n10UhjVRAeg==",
+			"version": "2.18.0",
+			"resolved": "https://registry.npmjs.org/@leaningtech/browserpod/-/browserpod-2.18.0.tgz",
+			"integrity": "sha512-ueutl4K2t84Yk4x+VMxrXIQtTj0H0dZqdecaeVZDO/RsjNnEMOKHbhT0lWTsIeAIVvbFbHp50m1QqrvTaHc/iQ==",
 			"license": "SEE LICENSE IN LICENSE.txt"
 		},
 		"node_modules/@polka/url": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
 	"name": "browsercode",
-	"version": "0.6.0",
+	"version": "0.6.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "browsercode",
-			"version": "0.6.0",
+			"version": "0.6.2",
 			"dependencies": {
 				"@iconify-json/mingcute": "^1.2.7",
 				"@iconify/svelte": "^5.2.1",
-				"@leaningtech/browserpod": "2.15.0",
+				"@leaningtech/browserpod": "2.16.0",
 				"@sveltejs/adapter-static": "^3.0.10",
 				"monaco-editor": "^0.55.1",
 				"qrcode": "^1.5.4"
@@ -811,9 +811,9 @@
 			}
 		},
 		"node_modules/@leaningtech/browserpod": {
-			"version": "2.15.0",
-			"resolved": "https://registry.npmjs.org/@leaningtech/browserpod/-/browserpod-2.15.0.tgz",
-			"integrity": "sha512-GANdIqoinJ+8Lrz4xEqM4ILUBLJRGaC8hXEo3RIeE1W9y3PPUy6Z1S4NtMdW3Uul4Uya93MNyEumOYnXVVHBPw==",
+			"version": "2.16.0",
+			"resolved": "https://registry.npmjs.org/@leaningtech/browserpod/-/browserpod-2.16.0.tgz",
+			"integrity": "sha512-NeGkHVtPRWxTk7JzsZWMqL81ysrHz+KEFhwaLyaEmnb/5YZUfFAzsCztP/Thoc7H3Of2D8y8a+1n10UhjVRAeg==",
 			"license": "SEE LICENSE IN LICENSE.txt"
 		},
 		"node_modules/@polka/url": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "browsercode",
 	"private": true,
-	"version": "0.6.1",
+	"version": "0.6.2",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",
@@ -38,7 +38,7 @@
 	"dependencies": {
 		"@iconify-json/mingcute": "^1.2.7",
 		"@iconify/svelte": "^5.2.1",
-		"@leaningtech/browserpod": "2.15.0",
+		"@leaningtech/browserpod": "2.16.0",
 		"@sveltejs/adapter-static": "^3.0.10",
 		"monaco-editor": "^0.55.1",
 		"qrcode": "^1.5.4"

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
 		"@iconify/svelte": "^5.2.1",
 		"@leaningtech/browserpod": "2.16.0",
 		"@sveltejs/adapter-static": "^3.0.10",
+		"fflate": "^0.8.3",
 		"monaco-editor": "^0.55.1",
 		"qrcode": "^1.5.4"
 	}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "browsercode",
 	"private": true,
-	"version": "0.6.2",
+	"version": "0.7.0",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",
@@ -38,7 +38,7 @@
 	"dependencies": {
 		"@iconify-json/mingcute": "^1.2.7",
 		"@iconify/svelte": "^5.2.1",
-		"@leaningtech/browserpod": "2.16.0",
+		"@leaningtech/browserpod": "2.18.0",
 		"@sveltejs/adapter-static": "^3.0.10",
 		"fflate": "^0.8.3",
 		"monaco-editor": "^0.55.1",

--- a/src/lib/agents/boot.ts
+++ b/src/lib/agents/boot.ts
@@ -1,9 +1,9 @@
 import type { BrowserPod } from '@leaningtech/browserpod';
 import { cliConfigs, toolItems } from '$lib/config/tools';
 import { writePodBinaryFile, writeToTerminal } from '$lib/pod/fs';
-import { isIos } from './platform';
-import { trackEvent } from './useLazyTracking';
 import type { PortalUpdate } from '$lib/pod/portals';
+import { isIos } from '$lib/utils/platform';
+import { trackEvent } from '$lib/utils/useLazyTracking';
 
 /**
  * Boots an agent tool's disk image into a pod and runs its CLI against the `#console`

--- a/src/lib/agents/boot.ts
+++ b/src/lib/agents/boot.ts
@@ -6,23 +6,22 @@ import { isIos } from '$lib/utils/platform';
 import { trackEvent } from '$lib/utils/useLazyTracking';
 
 /**
- * Boots an agent tool's disk image into a pod and runs its CLI against the `#console`
- * terminal. Portal events (and Claude's OAuth open events) stream through the callbacks
+ * Boots an agent tool's disk image into a pod and runs its CLI against `terminalEl`.
+ * Portal events (and Claude's OAuth open events) stream through the callbacks
  * configured in `cliConfigs`.
  */
 export async function bootCLI(
-	onPortalUpdate?: (update: PortalUpdate) => void,
-	tool: keyof typeof cliConfigs = 'gemini'
+	tool: keyof typeof cliConfigs,
+	terminalEl: HTMLElement,
+	onPortalUpdate?: (update: PortalUpdate) => void
 ) {
 	const { BrowserPod } = await import('@leaningtech/browserpod');
 
 	const config = cliConfigs[tool] ?? cliConfigs.gemini;
 	const toolLabel = toolItems.find((item) => item.id === tool)?.label ?? tool;
 
-	const consoleElement = document.querySelector('#console') as HTMLElement;
-
 	if (isIos()) {
-		consoleElement.textContent = 'unsupported';
+		terminalEl.textContent = 'unsupported';
 		return;
 	}
 
@@ -31,7 +30,7 @@ export async function bootCLI(
 		userImage: config.userImage,
 		storageKey: config.storageKey
 	});
-	const terminal = await pod.createDefaultTerminal(consoleElement);
+	const terminal = await pod.createDefaultTerminal(terminalEl);
 
 	pod.onPortal((portal) => {
 		const port = Number(portal?.port);

--- a/src/lib/components/IosUnsupportedModal.svelte
+++ b/src/lib/components/IosUnsupportedModal.svelte
@@ -1,20 +1,17 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import Icon from '@iconify/svelte';
+	import { isIos } from '$lib/utils/platform';
 
-	let isIos = $state(false);
+	let unsupported = $state(false);
 	let dismissed = $state(false);
 
 	onMount(() => {
-		const ua = navigator.userAgent;
-		// iPad in desktop mode reports MacIntel with touch points
-		isIos =
-			/iPad|iPhone|iPod/.test(ua) ||
-			(navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
+		unsupported = isIos();
 	});
 </script>
 
-{#if isIos && !dismissed}
+{#if unsupported && !dismissed}
 	<div
 		class="fixed inset-0 z-50 flex flex-col items-center justify-center bg-bc-abyss/80 px-6 backdrop-blur-md"
 		role="dialog"

--- a/src/lib/components/Portal.svelte
+++ b/src/lib/components/Portal.svelte
@@ -1,13 +1,31 @@
 <script lang="ts">
 	import Icon from '@iconify/svelte';
 	import QRCode from 'qrcode';
+	import type { PortalItem } from '$lib/stores/portals.svelte';
 
-	type PortalItem = { port: number; url: string };
+	type Props = {
+		src?: string;
+		portals?: PortalItem[];
+		selectedPort?: number | null;
+		showMenu?: boolean;
+		showInfo?: boolean;
+		copied?: boolean;
+		/** Failure text for the QR panel. Owned by the caller, which sets it from `onQrResult`. */
+		qrError?: string;
+		onPortChange?: (event: Event) => void;
+		onToggleMenu?: () => void;
+		onCopyLink?: () => void;
+		onOpenNewTab?: () => void;
+		onShowQrCode?: () => void;
+		onCloseOverlays?: () => void;
+		/** Reports the QR render outcome: a message when it fails, null once one renders. */
+		onQrResult?: (error: string | null) => void;
+	};
 
 	let {
 		src = '',
-		portals = [] as PortalItem[],
-		selectedPort = null as number | null,
+		portals = [],
+		selectedPort = null,
 		showMenu = false,
 		showInfo = false,
 		copied = false,
@@ -17,22 +35,9 @@
 		onCopyLink,
 		onOpenNewTab,
 		onShowQrCode,
-		onCloseOverlays
-	} = $props<{
-		src?: string;
-		portals?: PortalItem[];
-		selectedPort?: number | null;
-		showMenu?: boolean;
-		showInfo?: boolean;
-		copied?: boolean;
-		qrError?: string;
-		onPortChange?: (event: Event) => void;
-		onToggleMenu?: () => void;
-		onCopyLink?: () => void;
-		onOpenNewTab?: () => void;
-		onShowQrCode?: () => void;
-		onCloseOverlays?: () => void;
-	}>();
+		onCloseOverlays,
+		onQrResult
+	}: Props = $props();
 
 	let localQrCodeCanvas = $state<HTMLCanvasElement | null>(null);
 
@@ -46,9 +51,11 @@
 				errorCorrectionLevel: 'H',
 				color: { dark: '#000000', light: '#ffffff' }
 			});
+			// Clears a message left by an earlier failure; this render replaced that canvas.
+			onQrResult?.(null);
 		} catch (error) {
 			console.error('Failed to generate QR code:', error);
-			qrError = 'Unable to generate QR code';
+			onQrResult?.('Unable to generate QR code');
 		}
 	}
 
@@ -160,7 +167,10 @@
 						{#if qrError}
 							<div class="mt-3 text-center text-[12px] text-bc-coral">{qrError}</div>
 						{:else}
-							<div class="mt-3 max-w-50 truncate text-center text-[12px] text-white/40">
+							<!-- Wraps rather than truncates -->
+							<div
+								class="mt-3 w-full max-w-64 px-4 text-center text-[12px] break-all text-white/40"
+							>
 								{src}
 							</div>
 						{/if}

--- a/src/lib/components/Portal.svelte
+++ b/src/lib/components/Portal.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
 	import Icon from '@iconify/svelte';
 	import QRCode from 'qrcode';
-	import type { PortalItem } from '$lib/stores/portals.svelte';
+	import type { FrameStatus, PortalItem } from '$lib/stores/portals.svelte';
 
 	type Props = {
 		src?: string;
+		/** Gates the iframe; it mounts once the dev server has answered. */
+		frameStatus?: FrameStatus;
 		portals?: PortalItem[];
 		selectedPort?: number | null;
 		showMenu?: boolean;
@@ -18,12 +20,15 @@
 		onOpenNewTab?: () => void;
 		onShowQrCode?: () => void;
 		onCloseOverlays?: () => void;
-		/** Reports the QR render outcome: a message when it fails, null once one renders. */
+		/** Reports the QR render outcome; a message when it fails, null once one renders. */
 		onQrResult?: (error: string | null) => void;
+		/** Fires when the framed document loads. */
+		onFrameLoad?: () => void;
 	};
 
 	let {
 		src = '',
+		frameStatus = 'waiting',
 		portals = [],
 		selectedPort = null,
 		showMenu = false,
@@ -36,7 +41,8 @@
 		onOpenNewTab,
 		onShowQrCode,
 		onCloseOverlays,
-		onQrResult
+		onQrResult,
+		onFrameLoad
 	}: Props = $props();
 
 	let localQrCodeCanvas = $state<HTMLCanvasElement | null>(null);
@@ -141,12 +147,18 @@
 		<!-- Content -->
 		{#if src}
 			<div class="relative min-h-0 flex-1">
-				<iframe
-					{src}
-					id="portal"
-					title="Portal content"
-					class="h-full min-h-0 w-full border-none bg-white"
-				></iframe>
+				<!-- Mounts once the dev server answers; an early navigation hangs and stays blank. -->
+				{#if frameStatus !== 'waiting'}
+					<iframe
+						{src}
+						id="portal"
+						title="Portal content"
+						onload={onFrameLoad}
+						class="h-full min-h-0 w-full border-none {frameStatus === 'ready'
+							? 'bg-white'
+							: 'bg-bc-navy'}"
+					></iframe>
+				{/if}
 
 				{#if showInfo}
 					<div

--- a/src/lib/components/Sidebar.svelte
+++ b/src/lib/components/Sidebar.svelte
@@ -7,6 +7,7 @@
 	import { frameworkRailItems } from '$lib/config/frameworks';
 	import { trackEvent } from '$lib/utils/useLazyTracking';
 	import { openTour } from '$lib/stores/stepper.svelte';
+	import { NEW_ISSUE_URL } from '$lib/utils/bug-report';
 	import { navigateWithLeaveGuard } from '$lib/stores/leaveWarning.svelte';
 
 	let isHome = $derived($page.route.id === '/');
@@ -306,8 +307,10 @@
 						</span>
 						<span class="flex-1 truncate">UI tour</span>
 					</button>
+					<!-- The tracker is an external URL, so resolve() does not apply here. -->
+					<!-- eslint-disable svelte/no-navigation-without-resolve -->
 					<a
-						href="https://github.com/leaningtech/browsercode/issues/new"
+						href={NEW_ISSUE_URL}
 						target="_blank"
 						rel="noopener noreferrer"
 						onclick={() => trackEvent('Clicked Help', { action: 'report-bug' })}
@@ -320,6 +323,7 @@
 						</span>
 						<span class="flex-1 truncate">Report a bug</span>
 					</a>
+					<!-- eslint-enable svelte/no-navigation-without-resolve -->
 				</div>
 			</div>
 		</div>

--- a/src/lib/components/Terminal.svelte
+++ b/src/lib/components/Terminal.svelte
@@ -1,3 +1,8 @@
+<script lang="ts">
+	// The pod's terminal is attached to `consoleEl` by the host page's boot call.
+	let { consoleEl = $bindable(null) }: { consoleEl?: HTMLElement | null } = $props();
+</script>
+
 <div class="flex h-full min-h-0 w-full min-w-0 flex-col bg-[#0d0d0e]">
-	<div id="console" class="min-h-0 flex-1 bg-black p-4"></div>
+	<div bind:this={consoleEl} class="min-h-0 flex-1 bg-black p-4"></div>
 </div>

--- a/src/lib/components/ZenToggle.svelte
+++ b/src/lib/components/ZenToggle.svelte
@@ -1,0 +1,45 @@
+<script lang="ts">
+	import { tick } from 'svelte';
+	import Icon from '@iconify/svelte';
+	import { zenState, toggleZen } from '$lib/stores/zen.svelte';
+
+	// One toggle, two homes: the IDE rail and the agents terminal pane. Behaviour, icon-swap,
+	// tooltip and aria live here; each host passes its own classes since a rail icon and a glass
+	// pill over a terminal are legitimately different looks.
+	let {
+		baseClass = '',
+		activeClass = '',
+		idleClass = '',
+		size = 18,
+		onToggle
+	}: {
+		baseClass?: string;
+		activeClass?: string;
+		idleClass?: string;
+		size?: number;
+		onToggle?: () => void;
+	} = $props();
+
+	async function handle() {
+		toggleZen();
+		onToggle?.();
+		// Zen changes the available width; let the DOM settle, then refit anything sized off it
+		// (pod terminals, resizable splits) via the same resize event the IDE splitters use.
+		await tick();
+		window.dispatchEvent(new Event('resize'));
+	}
+</script>
+
+<button
+	type="button"
+	onclick={handle}
+	class="{baseClass} {zenState.on ? activeClass : idleClass}"
+	aria-pressed={zenState.on}
+	title={zenState.on ? 'Exit zen mode' : 'Zen mode'}
+>
+	<Icon
+		icon={zenState.on ? 'mingcute:fullscreen-exit-line' : 'mingcute:fullscreen-line'}
+		width={size}
+		height={size}
+	/>
+</button>

--- a/src/lib/components/ide/EditorPane.svelte
+++ b/src/lib/components/ide/EditorPane.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { onDestroy, onMount } from 'svelte';
+	import { onDestroy, onMount, untrack } from 'svelte';
 	import { SvelteMap } from 'svelte/reactivity';
 	import Icon from '@iconify/svelte';
 	import { fileIcon } from '$lib/ide/file-icons';
@@ -131,6 +131,12 @@
 			clearTimeout(saveTimeout);
 			saveTimeout = setTimeout(() => void session.saveFile(path), 1000);
 		}
+	});
+
+	// Saves are gated on `hasPortal`, so edits made during boot never persist. Flush
+	// them once the dev server is up.
+	$effect(() => {
+		if (session.hasPortal) untrack(() => void session.saveAll());
 	});
 
 	// Teardown: Monaco leaks DOM/workers if not disposed

--- a/src/lib/components/ide/EditorPane.svelte
+++ b/src/lib/components/ide/EditorPane.svelte
@@ -69,11 +69,23 @@
 		);
 	}
 
+	/** Applies a pending Search "jump to line" once the target's model is showing, then clears it. */
+	function consumeReveal(path: string) {
+		const reveal = session.revealRequest;
+		if (!editor || !reveal || reveal.path !== path) return;
+		editor.revealLineInCenter(reveal.line);
+		editor.setPosition({ lineNumber: reveal.line, column: reveal.column });
+		editor.focus();
+		session.revealRequest = null;
+	}
+
 	// Show the active tab: park the outgoing view state, attach the incoming
 	// model, restore its cursor/scroll.
 	$effect(() => {
 		const entry = session.openFiles.find((file) => file.path === session.selectedFile);
 		if (!editor || !monacoMod) return;
+		// Track the reveal request so a jump to the already-open file still re-runs this effect.
+		void session.revealRequest;
 		if (!entry) {
 			if (renderedPath) viewStates.set(renderedPath, editor.saveViewState());
 			editor.setModel(null);
@@ -84,6 +96,7 @@
 			// Session-side content change — push it into the model.
 			const model = editor.getModel();
 			if (model && model.getValue() !== entry.content) model.setValue(entry.content);
+			consumeReveal(entry.path);
 			return;
 		}
 		if (renderedPath) viewStates.set(renderedPath, editor.saveViewState());
@@ -93,6 +106,7 @@
 		const viewState = viewStates.get(entry.path);
 		if (viewState) editor.restoreViewState(viewState);
 		renderedPath = entry.path;
+		consumeReveal(entry.path);
 	});
 
 	// Dispose models and view states whose tab has been closed (or renamed away).

--- a/src/lib/components/ide/FileTreePanel.svelte
+++ b/src/lib/components/ide/FileTreePanel.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import Icon from '@iconify/svelte';
 	import { SvelteSet } from 'svelte/reactivity';
+	import { downloadFile } from '$lib/ide/download';
 	import { fileIcon, folderIcon } from '$lib/ide/file-icons';
 	import type { IdeSession } from '$lib/ide/session.svelte';
 
@@ -171,6 +172,15 @@
 			expandedFolders.add(to);
 		}
 		renaming = null;
+	}
+
+	async function requestDownload(path: string) {
+		closeMenu();
+		try {
+			await downloadFile(session, path);
+		} catch (error) {
+			console.error('Failed to download file:', error);
+		}
 	}
 
 	function requestDelete(path: string, isDir: boolean) {
@@ -353,6 +363,13 @@
 		{@render menuItem('mingcute:edit-2-line', 'Rename…', () =>
 			startRename(target.path, target.isDir)
 		)}
+		{#if !target.isDir}
+			{@render menuItem(
+				'mingcute:download-line',
+				'Download',
+				() => void requestDownload(target.path)
+			)}
+		{/if}
 		{@render menuItem(
 			'mingcute:delete-2-line',
 			'Delete',

--- a/src/lib/components/ide/IdeLanding.svelte
+++ b/src/lib/components/ide/IdeLanding.svelte
@@ -6,13 +6,32 @@
 	let url = $state('');
 	let error = $state('');
 
+	const maxFieldHeight = 112;
+
+	// The field wraps so a long URL stays fully readable instead of scrolling out of view.
+	function fitToContent(el: HTMLTextAreaElement) {
+		el.style.height = 'auto';
+		el.style.height = `${Math.min(el.scrollHeight, maxFieldHeight)}px`;
+		el.style.overflowY = el.scrollHeight > maxFieldHeight ? 'auto' : 'hidden';
+	}
+
+	function handleInput(el: HTMLTextAreaElement) {
+		error = '';
+		// A pasted URL can carry newlines or stray spaces; the field holds one value.
+		if (/\s/.test(el.value)) el.value = el.value.replace(/\s+/g, '');
+		url = el.value;
+		fitToContent(el);
+	}
+
+	// Resolves as you type, so the Clone action can show whether the URL is actually cloneable.
+	const target = $derived(parseGitHubUrl(url));
+
 	function openRepo() {
-		const parsed = parseGitHubUrl(url);
-		if (!parsed) {
+		if (!target) {
 			error = 'Use github.com/owner/repo or …/tree/branch/optional/dir';
 			return;
 		}
-		const { owner, repo, ref, dir } = parsed;
+		const { owner, repo, ref, dir } = target;
 		// Full reload so any prior pod is torn down cleanly.
 		window.location.href = `/ide/github/${owner}/${repo}/tree/${ref}${dir ? `/${dir}` : ''}`;
 	}
@@ -68,24 +87,41 @@
 			<div class="mb-2 text-[11px] font-medium tracking-widest text-bc-mist/40 uppercase">
 				Clone from GitHub
 			</div>
-			<div class="flex gap-2">
-				<input
-					bind:value={url}
-					oninput={() => (error = '')}
-					onkeydown={(e) => e.key === 'Enter' && openRepo()}
+			<!-- Field and action share one shell so the growing URL never drags the button out of place. -->
+			<label
+				class="glass-panel flex cursor-text items-center gap-1.5 rounded-xl border p-1.5 transition-colors focus-within:border-bc-azure/45 {error
+					? 'border-bc-coral/45'
+					: 'border-bc-mist/12'}"
+			>
+				<textarea
+					value={url}
+					oninput={(e) => handleInput(e.currentTarget)}
+					onkeydown={(e) => {
+						if (e.key !== 'Enter') return;
+						e.preventDefault();
+						openRepo();
+					}}
+					rows="1"
+					spellcheck="false"
+					aria-label="GitHub repository URL"
+					aria-invalid={error ? 'true' : undefined}
+					aria-describedby={error ? 'clone-error' : undefined}
 					placeholder="github.com/owner/repo/tree/main/dir"
-					class="glass-panel min-w-0 flex-1 rounded-lg border border-bc-mist/15 px-3 py-2 text-[13px] text-zinc-200 outline-none placeholder:text-white/25 focus:border-bc-azure/50"
-				/>
+					class="min-w-0 flex-1 resize-none overflow-hidden bg-transparent px-2 py-1 text-[13px] leading-5 break-all text-zinc-200 outline-none placeholder:text-white/25"
+				></textarea>
+				<!-- Fills in only once the URL resolves to a repo: the action reflects what the field holds. -->
 				<button
 					onclick={openRepo}
-					class="flex shrink-0 items-center gap-1.5 rounded-lg bg-bc-azure/90 px-4 py-2 text-[13px] font-medium text-white transition hover:bg-bc-azure"
+					class="flex shrink-0 cursor-pointer items-center gap-1.5 self-center rounded-md px-3 py-1 text-[13px] leading-5 font-medium transition-colors duration-200 focus-visible:ring-1 focus-visible:ring-bc-mist/60 focus-visible:outline-none {target
+						? 'bg-bc-azure text-white hover:bg-bc-azure/85'
+						: 'bg-white/6 text-bc-mist/55 hover:text-bc-mist/85'}"
 				>
 					<Icon icon="simple-icons:github" width="14" height="14" />
 					Clone
 				</button>
-			</div>
+			</label>
 			{#if error}
-				<p class="mt-2 text-[12px] text-bc-coral">{error}</p>
+				<p id="clone-error" class="mt-2 text-[12px] text-bc-coral">{error}</p>
 			{/if}
 		</div>
 	</div>

--- a/src/lib/components/ide/IdeLanding.svelte
+++ b/src/lib/components/ide/IdeLanding.svelte
@@ -1,26 +1,10 @@
 <script lang="ts">
 	import Icon from '@iconify/svelte';
 	import { frameworkRailItems } from '$lib/config/frameworks';
+	import { parseGitHubUrl } from '$lib/github/parse';
 
 	let url = $state('');
 	let error = $state('');
-
-	type ParsedRepo = { owner: string; repo: string; ref: string; dir: string };
-
-	function parseGitHubUrl(input: string): ParsedRepo | null {
-		const cleaned = input
-			.trim()
-			.replace(/^https?:\/\//, '')
-			.replace(/^github\.com\//, '')
-			.replace(/\.git$/, '')
-			.replace(/\/+$/, '');
-		const parts = cleaned.split('/').filter(Boolean);
-		if (parts.length < 2) return null;
-		const [owner, repo, keyword, ref, ...dirParts] = parts;
-		if (keyword === 'tree' && ref) return { owner, repo, ref, dir: dirParts.join('/') };
-		if (parts.length === 2) return { owner, repo, ref: 'main', dir: '' };
-		return null;
-	}
 
 	function openRepo() {
 		const parsed = parseGitHubUrl(url);

--- a/src/lib/components/ide/IdeLanding.svelte
+++ b/src/lib/components/ide/IdeLanding.svelte
@@ -2,6 +2,37 @@
 	import Icon from '@iconify/svelte';
 	import { frameworkRailItems } from '$lib/config/frameworks';
 
+	let url = $state('');
+	let error = $state('');
+
+	type ParsedRepo = { owner: string; repo: string; ref: string; dir: string };
+
+	function parseGitHubUrl(input: string): ParsedRepo | null {
+		const cleaned = input
+			.trim()
+			.replace(/^https?:\/\//, '')
+			.replace(/^github\.com\//, '')
+			.replace(/\.git$/, '')
+			.replace(/\/+$/, '');
+		const parts = cleaned.split('/').filter(Boolean);
+		if (parts.length < 2) return null;
+		const [owner, repo, keyword, ref, ...dirParts] = parts;
+		if (keyword === 'tree' && ref) return { owner, repo, ref, dir: dirParts.join('/') };
+		if (parts.length === 2) return { owner, repo, ref: 'main', dir: '' };
+		return null;
+	}
+
+	function openRepo() {
+		const parsed = parseGitHubUrl(url);
+		if (!parsed) {
+			error = 'Use github.com/owner/repo or …/tree/branch/optional/dir';
+			return;
+		}
+		const { owner, repo, ref, dir } = parsed;
+		// Full reload so any prior pod is torn down cleanly.
+		window.location.href = `/ide/github/${owner}/${repo}/tree/${ref}${dir ? `/${dir}` : ''}`;
+	}
+
 	function openFramework(id: string) {
 		window.location.href = `/ide?framework=${id}`;
 	}
@@ -10,7 +41,9 @@
 <div class="flex h-full w-full items-center justify-center overflow-auto p-6 text-zinc-300">
 	<div class="w-full max-w-lg">
 		<h1 class="mb-1 font-display text-lg font-semibold text-zinc-100">IDE Playground</h1>
-		<p class="mb-4 text-[13px] text-white/40">Start from a framework template.</p>
+		<p class="mb-4 text-[13px] text-white/40">
+			Start from a framework template or clone a GitHub repo.
+		</p>
 
 		<a
 			href="https://browserpod.io"
@@ -30,7 +63,7 @@
 			</span>
 		</a>
 
-		<div>
+		<div class="mb-6">
 			<div class="mb-2 text-[11px] font-medium tracking-widest text-bc-mist/40 uppercase">
 				Frameworks
 			</div>
@@ -45,6 +78,31 @@
 					</button>
 				{/each}
 			</div>
+		</div>
+
+		<div>
+			<div class="mb-2 text-[11px] font-medium tracking-widest text-bc-mist/40 uppercase">
+				Clone from GitHub
+			</div>
+			<div class="flex gap-2">
+				<input
+					bind:value={url}
+					oninput={() => (error = '')}
+					onkeydown={(e) => e.key === 'Enter' && openRepo()}
+					placeholder="github.com/owner/repo/tree/main/dir"
+					class="glass-panel min-w-0 flex-1 rounded-lg border border-bc-mist/15 px-3 py-2 text-[13px] text-zinc-200 outline-none placeholder:text-white/25 focus:border-bc-azure/50"
+				/>
+				<button
+					onclick={openRepo}
+					class="flex shrink-0 items-center gap-1.5 rounded-lg bg-bc-azure/90 px-4 py-2 text-[13px] font-medium text-white transition hover:bg-bc-azure"
+				>
+					<Icon icon="simple-icons:github" width="14" height="14" />
+					Clone
+				</button>
+			</div>
+			{#if error}
+				<p class="mt-2 text-[12px] text-bc-coral">{error}</p>
+			{/if}
 		</div>
 	</div>
 </div>

--- a/src/lib/components/ide/IdeLanding.svelte
+++ b/src/lib/components/ide/IdeLanding.svelte
@@ -6,21 +6,11 @@
 	let url = $state('');
 	let error = $state('');
 
-	const maxFieldHeight = 112;
-
-	// The field wraps so a long URL stays fully readable instead of scrolling out of view.
-	function fitToContent(el: HTMLTextAreaElement) {
-		el.style.height = 'auto';
-		el.style.height = `${Math.min(el.scrollHeight, maxFieldHeight)}px`;
-		el.style.overflowY = el.scrollHeight > maxFieldHeight ? 'auto' : 'hidden';
-	}
-
-	function handleInput(el: HTMLTextAreaElement) {
+	function handleInput(el: HTMLInputElement) {
 		error = '';
 		// A pasted URL can carry newlines or stray spaces; the field holds one value.
 		if (/\s/.test(el.value)) el.value = el.value.replace(/\s+/g, '');
 		url = el.value;
-		fitToContent(el);
 	}
 
 	// Resolves as you type, so the Clone action can show whether the URL is actually cloneable.
@@ -84,16 +74,46 @@
 		</div>
 
 		<div>
-			<div class="mb-2 text-[11px] font-medium tracking-widest text-bc-mist/40 uppercase">
-				Clone from GitHub
+			<div class="mb-2 flex items-center gap-2">
+				<span class="text-[11px] font-medium tracking-widest text-bc-mist/40 uppercase">
+					Clone from GitHub
+				</span>
+				<span class="group relative flex items-center">
+					<span
+						class="cursor-default rounded-full border border-bc-azure/30 bg-bc-azure/10 px-1.5 py-0.5 text-[9.5px] font-semibold tracking-wider text-bc-azure/85 uppercase"
+					>
+						Beta
+					</span>
+					<span
+						class="pointer-events-none absolute top-full left-0 z-50 mt-2 flex flex-col items-start opacity-0 transition-opacity duration-100 group-hover:opacity-100"
+					>
+						<span class="solid-panel ml-3 h-1.5 w-1.5 rotate-45 border-t border-l border-bc-mist/15"
+						></span>
+						<span
+							class="solid-panel -mt-px flex w-[26rem] max-w-[80vw] flex-col gap-2 rounded-md border border-bc-mist/15 px-3.5 py-3 text-[12.5px] leading-[1.6] text-zinc-300 shadow-[0_12px_40px_rgba(0,0,0,0.55)]"
+						>
+							<span>
+								Paste the GitHub URL of a working template, for example;
+								<span class="block font-mono text-[11.5px] break-all text-bc-mist">
+									github.com/vitejs/vite/tree/main/packages/create-vite/template-vanilla
+								</span>
+							</span>
+							<span class="text-zinc-400">
+								Browsing and editing a cloned repo works. Automatically building and running one is
+								still in beta.
+							</span>
+						</span>
+					</span>
+				</span>
 			</div>
-			<!-- Field and action share one shell so the growing URL never drags the button out of place. -->
+			<!-- Field and action share one shell, so the row keeps a fixed height whatever the URL length. -->
 			<label
-				class="glass-panel flex cursor-text items-center gap-1.5 rounded-xl border p-1.5 transition-colors focus-within:border-bc-azure/45 {error
+				class="glass-panel flex h-11 cursor-text items-center gap-1.5 rounded-xl border p-1.5 transition-colors focus-within:border-bc-azure/45 {error
 					? 'border-bc-coral/45'
 					: 'border-bc-mist/12'}"
 			>
-				<textarea
+				<input
+					type="text"
 					value={url}
 					oninput={(e) => handleInput(e.currentTarget)}
 					onkeydown={(e) => {
@@ -101,14 +121,15 @@
 						e.preventDefault();
 						openRepo();
 					}}
-					rows="1"
 					spellcheck="false"
+					autocomplete="off"
+					autocapitalize="off"
 					aria-label="GitHub repository URL"
 					aria-invalid={error ? 'true' : undefined}
 					aria-describedby={error ? 'clone-error' : undefined}
 					placeholder="github.com/owner/repo/tree/main/dir"
-					class="min-w-0 flex-1 resize-none overflow-hidden bg-transparent px-2 py-1 text-[13px] leading-5 break-all text-zinc-200 outline-none placeholder:text-white/25"
-				></textarea>
+					class="min-w-0 flex-1 bg-transparent px-2 py-1 text-[13px] leading-5 text-ellipsis whitespace-nowrap text-zinc-200 outline-none placeholder:text-white/25"
+				/>
 				<!-- Fills in only once the URL resolves to a repo: the action reflects what the field holds. -->
 				<button
 					onclick={openRepo}

--- a/src/lib/components/ide/IdeShell.svelte
+++ b/src/lib/components/ide/IdeShell.svelte
@@ -12,6 +12,8 @@
 	import type { PortalUpdate } from '$lib/pod/portals';
 	import { installLeaveGuard } from '$lib/stores/leaveWarning.svelte';
 	import { watchIsMobile } from '$lib/utils/viewport';
+	import ZenToggle from '$lib/components/ZenToggle.svelte';
+	import { zenState } from '$lib/stores/zen.svelte';
 
 	// Boot-log lines the preview loader streams, per boot mode.
 	const BOOT_LOG: Record<'framework' | 'github', string[]> = {
@@ -177,6 +179,8 @@
 	});
 
 	onDestroy(() => {
+		// Never leave the global chrome hidden after navigating away from /ide.
+		zenState.on = false;
 		portal.dispose();
 		session.shutdown();
 	});
@@ -206,7 +210,7 @@
 		class:is-mobile={isMobile}
 		bind:this={bodyEl}
 	>
-		<!-- Icon rail -->
+		<!-- Icon rail: panel navigators anchor to the top, global view toggles to the bottom. -->
 		<aside class="flex w-10 shrink-0 flex-col border-r border-bc-mist/10 bg-bc-navy">
 			<div class="flex flex-col gap-0.5 p-1 pt-2">
 				<button
@@ -218,6 +222,13 @@
 				>
 					<Icon icon="mingcute:file-line" width="18" height="18" />
 				</button>
+			</div>
+			<div class="mt-auto flex flex-col gap-0.5 p-1 pb-2">
+				<ZenToggle
+					baseClass="flex items-center justify-center rounded p-1.5 transition"
+					activeClass="bg-bc-azure/15 text-bc-azure"
+					idleClass="text-zinc-600 hover:bg-white/5 hover:text-zinc-300"
+				/>
 			</div>
 		</aside>
 

--- a/src/lib/components/ide/IdeShell.svelte
+++ b/src/lib/components/ide/IdeShell.svelte
@@ -9,6 +9,7 @@
 	import LoadingScene from '$lib/components/ide/LoadingScene.svelte';
 	import { fade } from 'svelte/transition';
 	import type { BootStage, IdeSession } from '$lib/ide/session.svelte';
+	import { downloadProject } from '$lib/ide/download';
 	import { PortalState } from '$lib/stores/portals.svelte';
 	import type { PortalUpdate } from '$lib/pod/portals';
 	import { installLeaveGuard } from '$lib/stores/leaveWarning.svelte';
@@ -56,6 +57,20 @@
 	} = $props();
 
 	let isCompatibleBrowser = $state(true);
+	let downloading = $state(false);
+
+	async function handleDownload() {
+		if (downloading || !session.hasPortal) return;
+		downloading = true;
+		try {
+			await downloadProject(session);
+		} catch (error) {
+			console.error('Failed to download project:', error);
+		} finally {
+			downloading = false;
+		}
+	}
+
 	let activePanel = $state<'files' | 'search' | null>('files');
 	let fileTree = $state<{ startCreate: (kind: 'file' | 'folder') => void } | null>(null);
 
@@ -203,6 +218,21 @@
 				<span class="ml-1 shrink-0 text-bc-mist/70">saving…</span>
 			{/if}
 		</div>
+		<button
+			type="button"
+			title="Download this project"
+			disabled={!session.hasPortal || downloading}
+			onclick={handleDownload}
+			class="flex shrink-0 items-center gap-1.5 rounded px-2 py-1 text-[11px] text-zinc-400 transition hover:bg-white/5 hover:text-zinc-200 disabled:pointer-events-none disabled:opacity-40"
+		>
+			<Icon
+				icon={downloading ? 'mingcute:loading-line' : 'mingcute:download-line'}
+				class={downloading ? 'animate-spin' : ''}
+				width="15"
+				height="15"
+			/>
+			<span>{downloading ? 'Zipping…' : 'Download'}</span>
+		</button>
 	</header>
 
 	<!-- ── Body ────────────────────────────────────────────────────────────── -->

--- a/src/lib/components/ide/IdeShell.svelte
+++ b/src/lib/components/ide/IdeShell.svelte
@@ -8,7 +8,8 @@
 	import LoadingScene from '$lib/components/ide/LoadingScene.svelte';
 	import { fade } from 'svelte/transition';
 	import type { BootStage, IdeSession } from '$lib/ide/session.svelte';
-	import { PortalState, type PortalUpdate } from '$lib/stores/portals.svelte';
+	import { PortalState } from '$lib/stores/portals.svelte';
+	import type { PortalUpdate } from '$lib/pod/portals';
 	import { consumeIntentionalNavigation } from '$lib/stores/leaveWarning.svelte';
 
 	// Boot-log lines the preview loader streams, per boot mode.

--- a/src/lib/components/ide/IdeShell.svelte
+++ b/src/lib/components/ide/IdeShell.svelte
@@ -78,7 +78,8 @@
 	// ports stay reachable through the port selector.
 	const portal = new PortalState({ preferredPort: () => session.appPort });
 
-	let previewLive = $derived(portal.portals.length > 0);
+	// Live once the framed document loaded, so the loader covers the server's start and first paint.
+	let previewLive = $derived(portal.frameStatus === 'ready');
 	let loaderVisible = $state(true);
 	$effect(() => {
 		if (!previewLive) loaderVisible = true;
@@ -429,6 +430,8 @@
 					{#if portal.portals.length > 0}
 						<Portal
 							src={portal.url}
+							frameStatus={portal.frameStatus}
+							onFrameLoad={portal.reportFrameLoaded}
 							portals={portal.portals}
 							selectedPort={portal.selectedPort}
 							showMenu={portal.showMenu}

--- a/src/lib/components/ide/IdeShell.svelte
+++ b/src/lib/components/ide/IdeShell.svelte
@@ -395,6 +395,7 @@
 							onOpenNewTab={portal.openInNewTab}
 							onShowQrCode={portal.showQRCode}
 							onCloseOverlays={portal.closeOverlays}
+							onQrResult={portal.reportQrResult}
 						/>
 					{/if}
 					<!-- Loader overlays the preview column, then cross-dissolves out into the iframe. -->

--- a/src/lib/components/ide/IdeShell.svelte
+++ b/src/lib/components/ide/IdeShell.svelte
@@ -4,6 +4,7 @@
 	import Portal from '$lib/components/Portal.svelte';
 	import EditorPane from '$lib/components/ide/EditorPane.svelte';
 	import FileTreePanel from '$lib/components/ide/FileTreePanel.svelte';
+	import SearchPanel from '$lib/components/ide/SearchPanel.svelte';
 	import TerminalTabs from '$lib/components/ide/TerminalTabs.svelte';
 	import LoadingScene from '$lib/components/ide/LoadingScene.svelte';
 	import { fade } from 'svelte/transition';
@@ -55,7 +56,7 @@
 	} = $props();
 
 	let isCompatibleBrowser = $state(true);
-	let activePanel = $state<'files' | null>('files');
+	let activePanel = $state<'files' | 'search' | null>('files');
 	let fileTree = $state<{ startCreate: (kind: 'file' | 'folder') => void } | null>(null);
 
 	// Frameworks with a declared app port keep the preview pinned to it; other
@@ -222,6 +223,15 @@
 				>
 					<Icon icon="mingcute:file-line" width="18" height="18" />
 				</button>
+				<button
+					onclick={() => (activePanel = activePanel === 'search' ? null : 'search')}
+					class="flex items-center justify-center rounded p-1.5 transition {activePanel === 'search'
+						? 'bg-bc-azure/15 text-bc-azure'
+						: 'text-zinc-600 hover:bg-white/5 hover:text-zinc-300'}"
+					title="Search"
+				>
+					<Icon icon="mingcute:search-line" width="18" height="18" />
+				</button>
 			</div>
 			<div class="mt-auto flex flex-col gap-0.5 p-1 pb-2">
 				<ZenToggle
@@ -242,44 +252,55 @@
 			></button>
 		{/if}
 
-		<!-- Side panel: file tree -->
+		<!-- Side panel: files or search -->
 		{#if activePanel}
 			<div
 				class="side-panel flex shrink-0 flex-col bg-bc-navy"
 				style="width: {isMobile ? 240 : filePanelWidth}px;"
 			>
-				<div class="flex items-center justify-between border-b border-bc-mist/10 px-3 py-1.5">
-					<span class="text-[10px] font-medium tracking-widest text-zinc-600 uppercase">
-						Files
-					</span>
-					<div class="flex items-center gap-0.5">
-						<button
-							type="button"
-							title="New file"
-							disabled={!session.podReady}
-							onclick={() => fileTree?.startCreate('file')}
-							class="rounded p-1 text-zinc-600 transition hover:bg-white/5 hover:text-zinc-300 disabled:pointer-events-none disabled:opacity-40"
-						>
-							<Icon icon="mingcute:file-new-line" width="13" height="13" />
-						</button>
-						<button
-							type="button"
-							title="New folder"
-							disabled={!session.podReady}
-							onclick={() => fileTree?.startCreate('folder')}
-							class="rounded p-1 text-zinc-600 transition hover:bg-white/5 hover:text-zinc-300 disabled:pointer-events-none disabled:opacity-40"
-						>
-							<Icon icon="mingcute:new-folder-line" width="13" height="13" />
-						</button>
+				{#if activePanel === 'files'}
+					<div class="flex items-center justify-between border-b border-bc-mist/10 px-3 py-1.5">
+						<span class="text-[10px] font-medium tracking-widest text-zinc-600 uppercase">
+							Files
+						</span>
+						<div class="flex items-center gap-0.5">
+							<button
+								type="button"
+								title="New file"
+								disabled={!session.podReady}
+								onclick={() => fileTree?.startCreate('file')}
+								class="rounded p-1 text-zinc-600 transition hover:bg-white/5 hover:text-zinc-300 disabled:pointer-events-none disabled:opacity-40"
+							>
+								<Icon icon="mingcute:file-new-line" width="13" height="13" />
+							</button>
+							<button
+								type="button"
+								title="New folder"
+								disabled={!session.podReady}
+								onclick={() => fileTree?.startCreate('folder')}
+								class="rounded p-1 text-zinc-600 transition hover:bg-white/5 hover:text-zinc-300 disabled:pointer-events-none disabled:opacity-40"
+							>
+								<Icon icon="mingcute:new-folder-line" width="13" height="13" />
+							</button>
+						</div>
 					</div>
-				</div>
-				<div class="flex-1 overflow-y-auto p-1.5">
-					<FileTreePanel
-						bind:this={fileTree}
-						{session}
-						onFileOpen={() => isMobile && (activePanel = null)}
-					/>
-				</div>
+					<div class="flex-1 overflow-y-auto p-1.5">
+						<FileTreePanel
+							bind:this={fileTree}
+							{session}
+							onFileOpen={() => isMobile && (activePanel = null)}
+						/>
+					</div>
+				{:else if activePanel === 'search'}
+					<div class="flex items-center border-b border-bc-mist/10 px-3 py-1.5">
+						<span class="text-[10px] font-medium tracking-widest text-zinc-600 uppercase">
+							Search
+						</span>
+					</div>
+					<div class="min-h-0 flex-1">
+						<SearchPanel {session} onFileOpen={() => isMobile && (activePanel = null)} />
+					</div>
+				{/if}
 			</div>
 
 			<!-- Divider: side panel / editor -->

--- a/src/lib/components/ide/IdeShell.svelte
+++ b/src/lib/components/ide/IdeShell.svelte
@@ -11,6 +11,7 @@
 	import { PortalState } from '$lib/stores/portals.svelte';
 	import type { PortalUpdate } from '$lib/pod/portals';
 	import { installLeaveGuard } from '$lib/stores/leaveWarning.svelte';
+	import { watchIsMobile } from '$lib/utils/viewport';
 
 	// Boot-log lines the preview loader streams, per boot mode.
 	const BOOT_LOG: Record<'framework' | 'github', string[]> = {
@@ -141,11 +142,13 @@
 	}
 
 	// ── Mobile detection ──────────────────────────────────────────────────────
-	function updateIsMobile() {
-		isMobile = window.matchMedia('(max-width: 768px)').matches;
-		// Close the side panel by default on mobile so it doesn't cover the view
-		if (isMobile && activePanel) activePanel = null;
-	}
+	onMount(() =>
+		watchIsMobile((mobile) => {
+			isMobile = mobile;
+			// Close the side panel by default on mobile so it doesn't cover the view
+			if (isMobile && activePanel) activePanel = null;
+		})
+	);
 
 	$effect(() => {
 		if (activeMobileView === 'terminal') {
@@ -154,14 +157,6 @@
 	});
 
 	// ── Boot ──────────────────────────────────────────────────────────────────
-	onMount(() => {
-		updateIsMobile();
-		const mql = window.matchMedia('(max-width: 768px)');
-		const onChange = () => updateIsMobile();
-		mql.addEventListener('change', onChange);
-		return () => mql.removeEventListener('change', onChange);
-	});
-
 	// Catches tab close/refresh/back-forward while a pod is running here.
 	onMount(() => installLeaveGuard());
 

--- a/src/lib/components/ide/IdeShell.svelte
+++ b/src/lib/components/ide/IdeShell.svelte
@@ -60,7 +60,7 @@
 	let downloading = $state(false);
 
 	async function handleDownload() {
-		if (downloading || !session.hasPortal) return;
+		if (downloading || !session.podReady) return;
 		downloading = true;
 		try {
 			await downloadProject(session);
@@ -219,21 +219,6 @@
 				<span class="ml-1 shrink-0 text-bc-mist/70">saving…</span>
 			{/if}
 		</div>
-		<button
-			type="button"
-			title="Download this project"
-			disabled={!session.hasPortal || downloading}
-			onclick={handleDownload}
-			class="flex shrink-0 items-center gap-1.5 rounded px-2 py-1 text-[11px] text-zinc-400 transition hover:bg-white/5 hover:text-zinc-200 disabled:pointer-events-none disabled:opacity-40"
-		>
-			<Icon
-				icon={downloading ? 'mingcute:loading-line' : 'mingcute:download-line'}
-				class={downloading ? 'animate-spin' : ''}
-				width="15"
-				height="15"
-			/>
-			<span>{downloading ? 'Zipping…' : 'Download'}</span>
-		</button>
 	</header>
 
 	<!-- ── Body ────────────────────────────────────────────────────────────── -->
@@ -292,7 +277,7 @@
 				{#if activePanel === 'files'}
 					<div class="flex items-center justify-between border-b border-bc-mist/10 px-3 py-1.5">
 						<span class="text-[10px] font-medium tracking-widest text-zinc-600 uppercase">
-							Files
+							Project files
 						</span>
 						<div class="flex items-center gap-0.5">
 							<button
@@ -312,6 +297,20 @@
 								class="rounded p-1 text-zinc-600 transition hover:bg-white/5 hover:text-zinc-300 disabled:pointer-events-none disabled:opacity-40"
 							>
 								<Icon icon="mingcute:new-folder-line" width="13" height="13" />
+							</button>
+							<button
+								type="button"
+								title={downloading ? 'Zipping project…' : 'Download this project as a zip'}
+								disabled={!session.podReady || downloading}
+								onclick={handleDownload}
+								class="rounded p-1 text-zinc-600 transition hover:bg-white/5 hover:text-zinc-300 disabled:pointer-events-none disabled:opacity-40"
+							>
+								<Icon
+									icon={downloading ? 'mingcute:loading-line' : 'mingcute:download-line'}
+									class={downloading ? 'animate-spin' : ''}
+									width="13"
+									height="13"
+								/>
 							</button>
 						</div>
 					</div>

--- a/src/lib/components/ide/IdeShell.svelte
+++ b/src/lib/components/ide/IdeShell.svelte
@@ -14,6 +14,8 @@
 	import type { PortalUpdate } from '$lib/pod/portals';
 	import { installLeaveGuard } from '$lib/stores/leaveWarning.svelte';
 	import { watchIsMobile } from '$lib/utils/viewport';
+	import { bugReportUrl } from '$lib/utils/bug-report';
+	import { trackEvent } from '$lib/utils/useLazyTracking';
 	import ZenToggle from '$lib/components/ZenToggle.svelte';
 	import { zenState } from '$lib/stores/zen.svelte';
 
@@ -77,6 +79,9 @@
 	// Frameworks with a declared app port keep the preview pinned to it; other
 	// ports stay reachable through the port selector.
 	const portal = new PortalState({ preferredPort: () => session.appPort });
+
+	// Recomputed as the preview moves ports, so a report always carries the live portal URL.
+	let bugReportHref = $derived(bugReportUrl({ repo: session.repo, previewUrl: portal.url }));
 
 	// Live once the framed document loaded, so the loader covers the server's start and first paint.
 	let previewLive = $derived(portal.frameStatus === 'ready');
@@ -250,6 +255,20 @@
 				</button>
 			</div>
 			<div class="mt-auto flex flex-col gap-0.5 p-1 pb-2">
+				<!-- The tracker is an external URL, so resolve() does not apply here. -->
+				<!-- eslint-disable svelte/no-navigation-without-resolve -->
+				<a
+					href={bugReportHref}
+					target="_blank"
+					rel="noopener noreferrer"
+					title="Report a bug"
+					aria-label="Report a bug"
+					onclick={() => trackEvent('Clicked Report Bug', { mode: session.mode })}
+					class="flex items-center justify-center rounded p-1.5 text-zinc-600 transition hover:bg-bc-coral/10 hover:text-bc-coral"
+				>
+					<Icon icon="mingcute:bug-line" width="18" height="18" />
+				</a>
+				<!-- eslint-enable svelte/no-navigation-without-resolve -->
 				<ZenToggle
 					baseClass="flex items-center justify-center rounded p-1.5 transition"
 					activeClass="bg-bc-azure/15 text-bc-azure"

--- a/src/lib/components/ide/IdeShell.svelte
+++ b/src/lib/components/ide/IdeShell.svelte
@@ -10,7 +10,7 @@
 	import type { BootStage, IdeSession } from '$lib/ide/session.svelte';
 	import { PortalState } from '$lib/stores/portals.svelte';
 	import type { PortalUpdate } from '$lib/pod/portals';
-	import { consumeIntentionalNavigation } from '$lib/stores/leaveWarning.svelte';
+	import { installLeaveGuard } from '$lib/stores/leaveWarning.svelte';
 
 	// Boot-log lines the preview loader streams, per boot mode.
 	const BOOT_LOG: Record<'framework' | 'github', string[]> = {
@@ -162,19 +162,8 @@
 		return () => mql.removeEventListener('change', onChange);
 	});
 
-	// Catches tab close/refresh/back-forward while a pod is running here — the in-app leave-warning
-	// modal (triggered via the sidebar) already asks and marks the navigation intentional, so this
-	// only fires for real browser-driven unloads.
-	function handleBeforeUnload(event: BeforeUnloadEvent) {
-		if (consumeIntentionalNavigation()) return;
-		event.preventDefault();
-		event.returnValue = '';
-	}
-
-	onMount(() => {
-		window.addEventListener('beforeunload', handleBeforeUnload);
-		return () => window.removeEventListener('beforeunload', handleBeforeUnload);
-	});
+	// Catches tab close/refresh/back-forward while a pod is running here.
+	onMount(() => installLeaveGuard());
 
 	onMount(async () => {
 		if (typeof Atomics?.waitAsync !== 'function') {

--- a/src/lib/components/ide/SearchPanel.svelte
+++ b/src/lib/components/ide/SearchPanel.svelte
@@ -1,0 +1,138 @@
+<script lang="ts">
+	import { onDestroy } from 'svelte';
+	import { SvelteMap } from 'svelte/reactivity';
+	import Icon from '@iconify/svelte';
+	import { fileIcon } from '$lib/ide/file-icons';
+	import { ProjectSearch, MAX_FILE_BYTES, type ContentMatch } from '$lib/ide/search.svelte';
+	import type { IdeSession } from '$lib/ide/session.svelte';
+
+	let { session, onFileOpen }: { session: IdeSession; onFileOpen?: () => void } = $props();
+
+	// Size cap label for the "large file" note.
+	const maxFileLabel = `${(MAX_FILE_BYTES / 1_000_000).toFixed(MAX_FILE_BYTES % 1_000_000 ? 1 : 0)} MB`;
+
+	// The route owns one session for this component's lifetime, so capturing it once is fine.
+	// svelte-ignore state_referenced_locally
+	const search = new ProjectSearch(session);
+	onDestroy(search.dispose);
+
+	// Content hits grouped by file.
+	let groups = $derived.by(() => {
+		const byPath = new SvelteMap<string, ContentMatch[]>();
+		for (const match of search.contentMatches) {
+			const list = byPath.get(match.path);
+			if (list) list.push(match);
+			else byPath.set(match.path, [match]);
+		}
+		return [...byPath];
+	});
+
+	function open(path: string) {
+		void session.openFile(path, true);
+		onFileOpen?.();
+	}
+
+	function openMatch(match: ContentMatch) {
+		void session.openAt(match.path, match.line, match.col);
+		onFileOpen?.();
+	}
+
+	function focusInput(el: HTMLInputElement) {
+		el.focus();
+	}
+</script>
+
+<div class="flex h-full min-h-0 flex-col">
+	<div class="px-2 pt-1.5 pb-1">
+		<div class="relative">
+			<Icon
+				icon="mingcute:search-line"
+				width="13"
+				height="13"
+				class="pointer-events-none absolute top-1/2 left-2 -translate-y-1/2 text-zinc-600"
+			/>
+			<input
+				use:focusInput
+				value={search.query}
+				oninput={(e) => search.setQuery(e.currentTarget.value)}
+				onkeydown={(e) => e.key === 'Enter' && search.runNow()}
+				placeholder="Search files"
+				spellcheck="false"
+				autocomplete="off"
+				class="w-full rounded border border-white/8 bg-zinc-900 py-1 pr-2 pl-7 text-[11px] text-zinc-100 outline-none placeholder:text-zinc-600 focus:border-bc-azure/50"
+			/>
+		</div>
+	</div>
+
+	<div class="min-h-0 flex-1 overflow-y-auto px-1.5 pb-2">
+		{#if !search.query.trim()}
+			<p class="px-1.5 py-2 text-[11px] leading-relaxed text-zinc-600">
+				Search across file names and contents.
+			</p>
+		{:else if search.busy && search.empty}
+			<p class="px-1.5 py-2 text-[11px] text-zinc-600">Searching…</p>
+		{:else if search.empty}
+			<p class="px-1.5 py-2 text-[11px] text-zinc-600">No results for “{search.query.trim()}”.</p>
+		{:else}
+			{#if search.fileMatches.length > 0}
+				<p
+					class="px-1.5 pt-1 pb-0.5 text-[10px] font-medium tracking-widest text-zinc-600 uppercase"
+				>
+					Files
+				</p>
+				{#each search.fileMatches as match (match.path)}
+					<button
+						type="button"
+						onclick={() => open(match.path)}
+						title={match.path}
+						class="flex w-full items-center gap-1.5 rounded px-1.5 py-0.5 text-left text-[11px] text-zinc-500 transition hover:bg-white/5 hover:text-zinc-300"
+					>
+						<Icon icon={fileIcon(match.path)} width="12" height="12" class="shrink-0" />
+						<span class="truncate">{match.path}</span>
+					</button>
+				{/each}
+			{/if}
+
+			{#if groups.length > 0}
+				<p
+					class="px-1.5 pt-2 pb-0.5 text-[10px] font-medium tracking-widest text-zinc-600 uppercase"
+				>
+					In files
+				</p>
+				{#each groups as [path, matches] (path)}
+					<div class="mb-0.5">
+						<div
+							class="flex items-center gap-1.5 px-1.5 py-0.5 text-[11px] text-zinc-400"
+							title={path}
+						>
+							<Icon icon={fileIcon(path)} width="12" height="12" class="shrink-0" />
+							<span class="truncate">{path}</span>
+							<span class="ml-auto shrink-0 text-[10px] text-zinc-600">{matches.length}</span>
+						</div>
+						{#each matches as match (`${match.line}:${match.col}`)}
+							<button
+								type="button"
+								onclick={() => openMatch(match)}
+								class="flex w-full items-baseline gap-2 rounded py-0.5 pr-1.5 pl-6 text-left text-[11px] text-zinc-500 transition hover:bg-white/5 hover:text-zinc-300"
+							>
+								<span class="shrink-0 text-[10px] text-zinc-600 tabular-nums">{match.line}</span>
+								<span class="truncate font-mono">{match.preview}</span>
+							</button>
+						{/each}
+					</div>
+				{/each}
+			{/if}
+
+			{#if search.truncated || search.skippedLarge > 0}
+				<p class="px-1.5 pt-2 text-[10px] leading-relaxed text-zinc-600">
+					{#if search.truncated}Showing the first {search.contentMatches.length} matches. Refine your
+						query to narrow results.{/if}
+					{#if search.skippedLarge > 0}
+						{search.skippedLarge} large file{search.skippedLarge === 1 ? '' : 's'} (over {maxFileLabel})
+						not searched. Open to find inside.
+					{/if}
+				</p>
+			{/if}
+		{/if}
+	</div>
+</div>

--- a/src/lib/github/parse.ts
+++ b/src/lib/github/parse.ts
@@ -7,7 +7,8 @@ const SEGMENT = /^[\w.-]+$/;
 /**
  * Parses a pasted GitHub URL or `owner/repo` shorthand. Accepts an optional
  * `/tree/<ref>/<dir…>`; a bare `owner/repo` defaults to the `main` branch and the repo root.
- * Returns null when the input isn't one of those shapes.
+ * Returns null when the input isn't one of those shapes, or names segments the route would
+ * refuse; so anything this returns can be navigated to.
  */
 export function parseGitHubUrl(input: string): ParsedRepo | null {
 	const cleaned = input
@@ -19,9 +20,17 @@ export function parseGitHubUrl(input: string): ParsedRepo | null {
 	const parts = cleaned.split('/').filter(Boolean);
 	if (parts.length < 2) return null;
 	const [owner, repo, keyword, ref, ...dirParts] = parts;
-	if (keyword === 'tree' && ref) return { owner, repo, ref, dir: dirParts.join('/') };
-	if (parts.length === 2) return { owner, repo, ref: 'main', dir: '' };
+	if (keyword === 'tree' && ref) return routable({ owner, repo, ref, dir: dirParts.join('/') });
+	if (parts.length === 2) return routable({ owner, repo, ref: 'main', dir: '' });
 	return null;
+}
+
+/**
+ * Drops a parse that the `/ide/github/…` route would reject, so callers fail in place rather
+ * than navigating to the route's error page.
+ */
+function routable(parsed: ParsedRepo): ParsedRepo | null {
+	return isValidRepoPath(parsed) ? parsed : null;
 }
 
 /** True if `dir` is empty (repo root) or a clean relative path with no `..` traversal. */

--- a/src/lib/github/parse.ts
+++ b/src/lib/github/parse.ts
@@ -1,0 +1,36 @@
+/** A repo location, in the shape the `/ide/github/...` route takes it. */
+export type ParsedRepo = { owner: string; repo: string; ref: string; dir: string };
+
+/** Characters allowed in an owner, repo, ref or directory segment. */
+const SEGMENT = /^[\w.-]+$/;
+
+/**
+ * Parses a pasted GitHub URL or `owner/repo` shorthand. Accepts an optional
+ * `/tree/<ref>/<dir…>`; a bare `owner/repo` defaults to the `main` branch and the repo root.
+ * Returns null when the input isn't one of those shapes.
+ */
+export function parseGitHubUrl(input: string): ParsedRepo | null {
+	const cleaned = input
+		.trim()
+		.replace(/^https?:\/\//, '')
+		.replace(/^github\.com\//, '')
+		.replace(/\.git$/, '')
+		.replace(/\/+$/, '');
+	const parts = cleaned.split('/').filter(Boolean);
+	if (parts.length < 2) return null;
+	const [owner, repo, keyword, ref, ...dirParts] = parts;
+	if (keyword === 'tree' && ref) return { owner, repo, ref, dir: dirParts.join('/') };
+	if (parts.length === 2) return { owner, repo, ref: 'main', dir: '' };
+	return null;
+}
+
+/** True if `dir` is empty (repo root) or a clean relative path with no `..` traversal. */
+function isValidDir(dir: string): boolean {
+	if (dir === '') return true;
+	return dir.split('/').every((segment) => SEGMENT.test(segment) && segment !== '..');
+}
+
+/** Guards the route params before a repo is cloned; rejects anything unroutable. */
+export function isValidRepoPath({ owner, repo, ref, dir }: ParsedRepo): boolean {
+	return SEGMENT.test(owner) && SEGMENT.test(repo) && SEGMENT.test(ref) && isValidDir(dir);
+}

--- a/src/lib/ide/download.ts
+++ b/src/lib/ide/download.ts
@@ -1,6 +1,7 @@
 /**
- * Zips every path in `session.projectFiles` as raw bytes so binary assets survive,
- * named after the session. Files created outside the IDE (e.g. the terminal) are skipped.
+ * Pulls files out of the pod and into the user's downloads: the whole project as a zip,
+ * or one file on its own. Files created outside the IDE (e.g. the terminal) aren't tracked
+ * in `session.projectFiles`, so the zip skips them.
  */
 import { zipSync } from 'fflate';
 import { readPodBinaryFile } from '$lib/pod/fs';
@@ -13,6 +14,22 @@ function zipFilename(label: string): string {
 		.replace(/[^a-zA-Z0-9._-]+/g, '-')
 		.replace(/^-+|-+$/g, '');
 	return `${slug || 'project'}.zip`;
+}
+
+/** Hands `bytes` to the browser as a download. */
+function triggerDownload(bytes: Uint8Array<ArrayBuffer>, filename: string, mimeType: string): void {
+	const blob = new Blob([bytes], { type: mimeType });
+	const url = URL.createObjectURL(blob);
+	try {
+		const anchor = document.createElement('a');
+		anchor.href = url;
+		anchor.download = filename;
+		document.body.appendChild(anchor);
+		anchor.click();
+		anchor.remove();
+	} finally {
+		URL.revokeObjectURL(url);
+	}
 }
 
 export async function downloadProject(session: IdeSession): Promise<void> {
@@ -28,17 +45,18 @@ export async function downloadProject(session: IdeSession): Promise<void> {
 		files[path] = await readPodBinaryFile(pod, `${session.workdir}/${path}`);
 	}
 
-	const zipped = zipSync(files);
-	const blob = new Blob([zipped], { type: 'application/zip' });
-	const url = URL.createObjectURL(blob);
-	try {
-		const anchor = document.createElement('a');
-		anchor.href = url;
-		anchor.download = zipFilename(session.displayLabel);
-		document.body.appendChild(anchor);
-		anchor.click();
-		anchor.remove();
-	} finally {
-		URL.revokeObjectURL(url);
-	}
+	triggerDownload(zipSync(files), zipFilename(session.displayLabel), 'application/zip');
+}
+
+/** Downloads a single project-relative file under its own name. */
+export async function downloadFile(session: IdeSession, path: string): Promise<void> {
+	const pod = session.pod;
+	if (!pod) return;
+
+	// Flush this file's pending edits so the download matches the editor.
+	await session.saveFile(path);
+
+	const bytes = await readPodBinaryFile(pod, `${session.workdir}/${path}`);
+	const name = path.split('/').pop() || 'download';
+	triggerDownload(bytes, name, 'application/octet-stream');
 }

--- a/src/lib/ide/download.ts
+++ b/src/lib/ide/download.ts
@@ -1,0 +1,44 @@
+/**
+ * Zips every path in `session.projectFiles` as raw bytes so binary assets survive,
+ * named after the session. Files created outside the IDE (e.g. the terminal) are skipped.
+ */
+import { zipSync } from 'fflate';
+import { readPodBinaryFile } from '$lib/pod/fs';
+import type { IdeSession } from './session.svelte';
+
+/** Turn a display label into a safe zip filename. */
+function zipFilename(label: string): string {
+	const slug = label
+		.trim()
+		.replace(/[^a-zA-Z0-9._-]+/g, '-')
+		.replace(/^-+|-+$/g, '');
+	return `${slug || 'project'}.zip`;
+}
+
+export async function downloadProject(session: IdeSession): Promise<void> {
+	const pod = session.pod;
+	if (!pod) return;
+
+	// Flush unsaved edits first so the zip matches the editor.
+	await session.saveAll();
+
+	// Read sequentially; projects are small.
+	const files: Record<string, Uint8Array> = {};
+	for (const path of session.projectFiles) {
+		files[path] = await readPodBinaryFile(pod, `${session.workdir}/${path}`);
+	}
+
+	const zipped = zipSync(files);
+	const blob = new Blob([zipped], { type: 'application/zip' });
+	const url = URL.createObjectURL(blob);
+	try {
+		const anchor = document.createElement('a');
+		anchor.href = url;
+		anchor.download = zipFilename(session.displayLabel);
+		document.body.appendChild(anchor);
+		anchor.click();
+		anchor.remove();
+	} finally {
+		URL.revokeObjectURL(url);
+	}
+}

--- a/src/lib/ide/native-deps.ts
+++ b/src/lib/ide/native-deps.ts
@@ -1,0 +1,103 @@
+/**
+ * Per-framework npm `overrides` injected into a cloned GitHub repo's package.json before
+ * install.
+ */
+
+type Manifest = {
+	dependencies?: Record<string, string>;
+	devDependencies?: Record<string, string>;
+	overrides?: Record<string, unknown>;
+	[key: string]: unknown;
+};
+
+/** What the repo declares, package name to version spec, dependencies and devDependencies. */
+type DeclaredDeps = Map<string, string>;
+
+type OverrideRule = {
+	framework: string;
+	applies: (deps: DeclaredDeps) => boolean;
+	overrides: Record<string, string>;
+	/** Echoed to Output after the packages pinned; a lowercase clause saying why they are. */
+	reason: string;
+};
+
+const OVERRIDE_RULES: OverrideRule[] = [
+	{
+		framework: 'Vite 8+',
+		applies: (deps) => majorAtLeast(deps, 'vite', 8),
+		overrides: {
+			'@napi-rs/wasm-runtime': '1.1.6'
+		},
+		reason: 'the wasm runtime; it otherwise fails to instantiate in the pod'
+	},
+	{
+		framework: 'Vite 7 and earlier',
+		applies: (deps) => majorBelow(deps, 'vite', 8),
+		overrides: {
+			esbuild: 'npm:esbuild-wasm@0.25.11',
+			rollup: 'npm:@rollup/wasm-node@4.52.4'
+		},
+		reason: 'the native esbuild and rollup binaries cannot run in the pod'
+	}
+];
+
+/** Highest major the spec could install. Null means no ceiling at all. */
+function highestMajor(spec: string): number | null {
+	if (spec.includes('>') && !spec.includes('<')) return null;
+	const versions = spec.match(/\d+(?:\.\d+)*/g);
+	if (!versions) return null;
+	return Math.max(...versions.map((version) => Number.parseInt(version, 10)));
+}
+
+/** True when `name` is declared and can install `major` or newer, an unversioned spec included. */
+function majorAtLeast(deps: DeclaredDeps, name: string, major: number): boolean {
+	const spec = deps.get(name);
+	if (spec === undefined) return false;
+	const highest = highestMajor(spec);
+	return highest === null || highest >= major;
+}
+
+/** True when `name` is declared and cannot install `major` or newer. */
+function majorBelow(deps: DeclaredDeps, name: string, major: number): boolean {
+	const spec = deps.get(name);
+	if (spec === undefined) return false;
+	const highest = highestMajor(spec);
+	return highest !== null && highest < major;
+}
+
+/**
+ * Forces every matching rule's overrides into the manifest, winning over the repo's own entry
+ * for the same package. Returns null when nothing changed: no rule matched, ours already match,
+ * or the manifest would not parse.
+ */
+export function patchClonedManifest(
+	manifestRaw: string
+): { patched: string; notes: string[] } | null {
+	let manifest: Manifest;
+	try {
+		manifest = JSON.parse(manifestRaw) as Manifest;
+	} catch {
+		return null;
+	}
+	const deps: DeclaredDeps = new Map(
+		Object.entries({ ...manifest.dependencies, ...manifest.devDependencies })
+	);
+	const overrides = { ...manifest.overrides };
+	const notes: string[] = [];
+	for (const rule of OVERRIDE_RULES) {
+		if (!rule.applies(deps)) continue;
+		const applied: string[] = [];
+		for (const [name, spec] of Object.entries(rule.overrides)) {
+			if (overrides[name] === spec) continue;
+			overrides[name] = spec;
+			applied.push(`${name}@${spec}`);
+		}
+		if (applied.length === 0) continue;
+		notes.push(`${rule.framework}: pinned ${applied.join(', ')} — ${rule.reason}`);
+	}
+	if (notes.length === 0) return null;
+	manifest.overrides = overrides;
+	const indent = manifestRaw.match(/^([ \t]+)"/m)?.[1] ?? '  ';
+	const patched = JSON.stringify(manifest, null, indent) + (manifestRaw.endsWith('\n') ? '\n' : '');
+	return { patched, notes };
+}

--- a/src/lib/ide/search.svelte.ts
+++ b/src/lib/ide/search.svelte.ts
@@ -1,0 +1,238 @@
+import { SvelteMap, SvelteSet } from 'svelte/reactivity';
+import { readPodFileWithinLimit } from '$lib/pod/fs';
+import type { IdeSession } from '$lib/ide/session.svelte';
+
+/** A project file whose name/path matched the query. */
+export type FileMatch = { path: string };
+
+/** A single matching line inside a file; `line`/`col` are 1-based, used to jump the editor there. */
+export type ContentMatch = { path: string; line: number; col: number; preview: string };
+
+/** Result caps; the panel notes when it truncated. Sized for large GitHub clones. */
+const MAX_RESULTS = 200;
+const MAX_MATCHES_PER_FILE = 40;
+/**
+ * Files larger than this are skipped for content search (read size-first, so the bytes are never
+ * pulled into memory). Exported so the panel's "large file" note stays in sync with the limit.
+ */
+export const MAX_FILE_BYTES = 1_000_000;
+const PREVIEW_LENGTH = 200;
+const DEBOUNCE_MS = 150;
+
+/** Extensions we never read for a content search (binary or non-text). */
+const SKIP_EXT = new Set([
+	// images
+	'png',
+	'jpg',
+	'jpeg',
+	'gif',
+	'bmp',
+	'ico',
+	'webp',
+	'avif',
+	'tiff',
+	'psd',
+	// fonts
+	'woff',
+	'woff2',
+	'ttf',
+	'otf',
+	'eot',
+	// audio / video
+	'mp3',
+	'wav',
+	'ogg',
+	'flac',
+	'aac',
+	'mp4',
+	'webm',
+	'mov',
+	'avi',
+	'mkv',
+	'm4a',
+	// archives
+	'zip',
+	'gz',
+	'tgz',
+	'tar',
+	'rar',
+	'7z',
+	'bz2',
+	'xz',
+	// binaries / data
+	'wasm',
+	'exe',
+	'dll',
+	'so',
+	'dylib',
+	'bin',
+	'dat',
+	'class',
+	'jar',
+	'pdf',
+	'sqlite',
+	'db',
+	'lockb',
+	'node'
+]);
+
+/** Exact filenames we skip; generated or oversized files with no search value. */
+const SKIP_NAME = new Set(['package-lock.json', 'yarn.lock', 'pnpm-lock.yaml', 'bun.lockb']);
+
+const basename = (path: string): string => path.slice(path.lastIndexOf('/') + 1);
+
+/**
+ * BrowserPod has no stdout capture or directory listing, so grep is not possible; matching runs
+ * in JS over file contents, cached in `index` so debounced keystrokes don't re-read the tree.
+ */
+export class ProjectSearch {
+	query = $state('');
+	fileMatches = $state<FileMatch[]>([]);
+	contentMatches = $state<ContentMatch[]>([]);
+	busy = $state(false);
+	/** True when results were capped at {@link MAX_RESULTS}. */
+	truncated = $state(false);
+	/** How many text files were skipped this run for exceeding {@link MAX_FILE_BYTES}. */
+	skippedLarge = $state(0);
+
+	/** Cached file contents; `null` marks a file skipped as too large (so it isn't re-read needlessly). */
+	private index = new SvelteMap<string, string | null>();
+	private debounceTimer: ReturnType<typeof setTimeout> | undefined;
+	/** Bumped per run so a superseded async search bails after its next await. */
+	private runToken = 0;
+
+	constructor(private session: IdeSession) {}
+
+	/** Updates the query and schedules a debounced search. */
+	setQuery = (value: string): void => {
+		this.query = value;
+		clearTimeout(this.debounceTimer);
+		this.debounceTimer = setTimeout(() => void this.run(), DEBOUNCE_MS);
+	};
+
+	/** Runs the current query immediately (skips the debounce), e.g. on Enter. */
+	runNow = (): void => {
+		clearTimeout(this.debounceTimer);
+		void this.run();
+	};
+
+	/** True when there is nothing to show for a non-empty, settled query. */
+	get empty(): boolean {
+		return !this.busy && this.fileMatches.length === 0 && this.contentMatches.length === 0;
+	}
+
+	private isTextCandidate(path: string): boolean {
+		const name = basename(path).toLowerCase();
+		if (SKIP_NAME.has(name)) return false;
+		if (name.endsWith('.map') || name.endsWith('.min.js') || name.endsWith('.min.css'))
+			return false;
+		const dot = name.lastIndexOf('.');
+		const ext = dot >= 0 ? name.slice(dot + 1) : '';
+		return !SKIP_EXT.has(ext);
+	}
+
+	/** Content for `path`, preferring the live editor buffer and caching pod reads. */
+	private async contentOf(path: string): Promise<string | null> {
+		const open = this.session.openFiles.find((file) => file.path === path);
+		if (open) {
+			// The live buffer wins; drop any cached copy so the next read after close is fresh.
+			this.index.delete(path);
+			return open.content;
+		}
+		const cached = this.index.get(path);
+		if (cached !== undefined) return cached;
+		const pod = this.session.pod;
+		if (!pod) return null;
+		try {
+			const content = await readPodFileWithinLimit(
+				pod,
+				`${this.session.workdir}/${path}`,
+				MAX_FILE_BYTES
+			);
+			this.index.set(path, content);
+			return content;
+		} catch {
+			return null;
+		}
+	}
+
+	private async run(): Promise<void> {
+		const token = ++this.runToken;
+		const raw = this.query.trim();
+		if (!raw) {
+			this.fileMatches = [];
+			this.contentMatches = [];
+			this.truncated = false;
+			this.skippedLarge = 0;
+			this.busy = false;
+			return;
+		}
+		this.busy = true;
+		const needle = raw.toLowerCase();
+		const files = this.session.projectFiles;
+
+		// Prune entries for files that were deleted or renamed away.
+		const known = new SvelteSet(files);
+		for (const key of this.index.keys()) if (!known.has(key)) this.index.delete(key);
+
+		// Filename matches
+		const fileMatches: { path: string; rank: number }[] = [];
+		for (const path of files) {
+			const base = basename(path).toLowerCase();
+			const inBase = base.includes(needle);
+			if (!inBase && !path.toLowerCase().includes(needle)) continue;
+			fileMatches.push({ path, rank: inBase ? (base.startsWith(needle) ? 0 : 1) : 2 });
+		}
+		fileMatches.sort((a, b) => a.rank - b.rank || a.path.length - b.path.length);
+
+		// Content matches
+		const contentMatches: ContentMatch[] = [];
+		let truncated = false;
+		let skippedLarge = 0;
+		for (const path of files) {
+			if (contentMatches.length >= MAX_RESULTS) {
+				truncated = true;
+				break;
+			}
+			if (!this.isTextCandidate(path)) continue;
+			const content = await this.contentOf(path);
+			if (token !== this.runToken) return; // superseded by a newer query
+			if (content === null) {
+				// Oversized files are cached as null; read errors stay uncached (get returns undefined).
+				if (this.index.get(path) === null) skippedLarge++;
+				continue;
+			}
+
+			const lines = content.split('\n');
+			let perFile = 0;
+			for (let i = 0; i < lines.length; i++) {
+				const col = lines[i].toLowerCase().indexOf(needle);
+				if (col < 0) continue;
+				contentMatches.push({
+					path,
+					line: i + 1,
+					col: col + 1,
+					preview: lines[i].trim().slice(0, PREVIEW_LENGTH)
+				});
+				if (++perFile >= MAX_MATCHES_PER_FILE) break;
+				if (contentMatches.length >= MAX_RESULTS) {
+					truncated = true;
+					break;
+				}
+			}
+			if (truncated) break;
+		}
+
+		if (token !== this.runToken) return;
+		this.fileMatches = fileMatches.slice(0, MAX_RESULTS).map(({ path }) => ({ path }));
+		this.contentMatches = contentMatches;
+		this.truncated = truncated;
+		this.skippedLarge = skippedLarge;
+		this.busy = false;
+	}
+
+	/** Clears the debounce timer; call on host unmount. */
+	dispose = (): void => {
+		clearTimeout(this.debounceTimer);
+	};
+}

--- a/src/lib/ide/session.svelte.ts
+++ b/src/lib/ide/session.svelte.ts
@@ -49,6 +49,8 @@ export class IdeSession {
 	openFiles = $state<OpenFile[]>([]);
 	/** Path of the active tab; '' when no tab is open. */
 	selectedFile = $state('');
+	/** Pending scroll-to-location (1-based) the editor consumes once the file's model is active. */
+	revealRequest = $state<{ path: string; line: number; column: number } | null>(null);
 	loading = $state(true);
 	isSaving = $state(false);
 	hasPortal = $state(false);
@@ -466,6 +468,15 @@ export class IdeSession {
 		} finally {
 			this.loading = false;
 		}
+	}
+
+	/**
+	 * Opens `path` as a preview tab and reveals `line`/`column` (1-based). The request is set
+	 * before opening so it survives an already-open file, applied once the model attaches.
+	 */
+	async openAt(path: string, line: number, column = 1): Promise<void> {
+		this.revealRequest = { path, line, column };
+		await this.openFile(path, true);
 	}
 
 	/** Promotes a preview tab to a permanent one; safe to call while the tab is still loading. */

--- a/src/lib/ide/session.svelte.ts
+++ b/src/lib/ide/session.svelte.ts
@@ -508,6 +508,12 @@ export class IdeSession {
 		if (entry) await this.saveEntry(entry);
 	}
 
+	/** Flushes every tab with unsaved edits to the pod. */
+	async saveAll(): Promise<void> {
+		const dirty = this.openFiles.filter((file) => file.content !== file.savedContent);
+		await Promise.all(dirty.map((entry) => this.saveEntry(entry)));
+	}
+
 	private async saveEntry(entry: OpenFile): Promise<void> {
 		// Saving only makes sense once the dev server is reachable; earlier writes
 		// would race the template hydration.

--- a/src/lib/ide/session.svelte.ts
+++ b/src/lib/ide/session.svelte.ts
@@ -63,6 +63,9 @@ export class IdeSession {
 	/** Directory the project lives in inside the pod; pod file paths resolve against it. */
 	workdir = POD_HOME;
 	private githubSlug = $state('');
+	/** Repo URL this session clones from: `git clone` appends `.git`, bug reports link it as-is. */
+	private githubUrl = $state('');
+	private githubRef = $state('');
 
 	pod: BrowserPod | null = null;
 	outputTerminal: Terminal | null = null;
@@ -86,6 +89,12 @@ export class IdeSession {
 	/** Label shown in the IDE shell; framework label, or owner/repo[/dir] in GitHub mode. */
 	get displayLabel(): string {
 		return this.mode === 'github' ? this.githubSlug : this.config.label;
+	}
+
+	/** What this session cloned; null in framework mode. Carried into bug reports. */
+	get repo(): { url: string; ref: string } | null {
+		if (this.mode !== 'github' || !this.githubUrl) return null;
+		return { url: this.githubUrl, ref: this.githubRef };
 	}
 
 	/** Preview is pinned to this port when set. Unknown for arbitrary GitHub repos. */
@@ -176,6 +185,8 @@ export class IdeSession {
 		this.booting = true;
 		this.mode = 'github';
 		this.githubSlug = dir ? `${owner}/${repo}/${dir}` : `${owner}/${repo}`;
+		this.githubUrl = `https://github.com/${owner}/${repo}`;
+		this.githubRef = ref;
 		const token = ++this.bootToken;
 		try {
 			this.bootStage = 'booting';
@@ -202,7 +213,7 @@ export class IdeSession {
 			// git manages its own colors (no TTY here, so none) — forcing COLOR_ENV would change nothing.
 			await this.runInOutput(
 				'git',
-				['clone', '--depth', '1', '--branch', ref, `https://github.com/${owner}/${repo}.git`],
+				['clone', '--depth', '1', '--branch', ref, `${this.githubUrl}.git`],
 				{ cwd: POD_HOME, color: false }
 			);
 			if (this.cancelled(token)) return;

--- a/src/lib/ide/session.svelte.ts
+++ b/src/lib/ide/session.svelte.ts
@@ -14,6 +14,7 @@ import {
 	writeToTerminal
 } from '$lib/pod/fs';
 import { ANSI, BP_RC, BP_RC_PATH } from './shell-rc';
+import { patchClonedManifest } from './native-deps';
 import { fetchRepoTree } from '$lib/github/api';
 import { trackEvent } from '$lib/utils/useLazyTracking';
 import type { PortalUpdate } from '$lib/pod/portals';
@@ -221,6 +222,11 @@ export class IdeSession {
 			// The working tree exists now — let the editor read from the pod.
 			this.podReady = true;
 
+			// Patch package.json before the first tab opens, so the editor shows the
+			// manifest install will actually see.
+			await this.applyManifestPatches();
+			if (this.cancelled(token)) return;
+
 			const initialFile = this.projectFiles[0];
 			if (initialFile) await this.openFile(initialFile);
 			else this.loading = false;
@@ -328,6 +334,26 @@ export class IdeSession {
 			await writePodFile(pod, BP_RC_PATH, BP_RC);
 		} catch (error) {
 			console.warn('Could not write shell rc:', error);
+		}
+	}
+
+	private async applyManifestPatches(): Promise<void> {
+		if (!this.pod) return;
+		const manifestPath = `${this.workdir}/package.json`;
+		try {
+			const raw = await readPodFile(this.pod, manifestPath);
+			const result = patchClonedManifest(raw);
+			if (!result) {
+				this.termWrite(`\r\n${ANSI.dim}No dependency patches apply to this repo.${ANSI.reset}\r\n`);
+				return;
+			}
+			await writePodFile(this.pod, manifestPath, result.patched);
+			for (const note of result.notes) this.termWrite(`\r\n${ANSI.dim}${note}${ANSI.reset}\r\n`);
+		} catch (error) {
+			this.termWrite(
+				`\r\n${ANSI.coral}Could not patch package.json; installing the repo as cloned.${ANSI.reset}\r\n`
+			);
+			console.warn('Could not patch the cloned manifest:', error);
 		}
 	}
 

--- a/src/lib/ide/session.svelte.ts
+++ b/src/lib/ide/session.svelte.ts
@@ -6,11 +6,17 @@ import {
 	type FrameworkConfig,
 	type FrameworkId
 } from '$lib/config/frameworks';
-import { POD_HOME, readPodFile, writePodFile, writePodBinaryFile, writeToTerminal } from './pod-fs';
+import {
+	POD_HOME,
+	readPodFile,
+	writePodFile,
+	writePodBinaryFile,
+	writeToTerminal
+} from '$lib/pod/fs';
 import { ANSI, BP_RC, BP_RC_PATH } from './shell-rc';
 import { fetchRepoTree } from '$lib/github/api';
 import { trackEvent } from '$lib/utils/useLazyTracking';
-import type { PortalUpdate } from '$lib/stores/portals.svelte';
+import type { PortalUpdate } from '$lib/pod/portals';
 
 // Re-exported so the boot-owning routes keep a single import site for session types.
 export type { PortalUpdate };
@@ -52,7 +58,7 @@ export class IdeSession {
 
 	/** Which boot path produced this session; drives the label, appPort and workdir. */
 	mode = $state<'framework' | 'github'>('framework');
-	/** Directory the project lives in inside the pod; pod-fs paths resolve against it. */
+	/** Directory the project lives in inside the pod; pod file paths resolve against it. */
 	workdir = POD_HOME;
 	private githubSlug = $state('');
 

--- a/src/lib/ide/shell-rc.ts
+++ b/src/lib/ide/shell-rc.ts
@@ -1,4 +1,4 @@
-import { POD_HOME } from './pod-fs';
+import { POD_HOME } from '$lib/pod/fs';
 
 export const BP_RC_PATH = `${POD_HOME}/.bp_rc`;
 

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,1 +1,0 @@
-// place files you want to import through the `$lib` alias in this folder.

--- a/src/lib/pod/fs.ts
+++ b/src/lib/pod/fs.ts
@@ -20,6 +20,17 @@ export async function readPodFile(pod: BrowserPod, absPath: string): Promise<str
 	return content;
 }
 
+/** Reads a file as raw bytes so binary assets survive intact. */
+export async function readPodBinaryFile(pod: BrowserPod, absPath: string): Promise<Uint8Array> {
+	const file = (await pod.openFile(absPath, 'binary')) as BinaryFile;
+	try {
+		const size = await file.getSize();
+		return new Uint8Array(await file.read(size));
+	} finally {
+		await file.close();
+	}
+}
+
 /** Reads a text file, or returns null (without reading it) when larger than `maxBytes`. */
 export async function readPodFileWithinLimit(
 	pod: BrowserPod,

--- a/src/lib/pod/fs.ts
+++ b/src/lib/pod/fs.ts
@@ -20,6 +20,22 @@ export async function readPodFile(pod: BrowserPod, absPath: string): Promise<str
 	return content;
 }
 
+/** Reads a text file, or returns null (without reading it) when larger than `maxBytes`. */
+export async function readPodFileWithinLimit(
+	pod: BrowserPod,
+	absPath: string,
+	maxBytes: number
+): Promise<string | null> {
+	const file = (await pod.openFile(absPath, 'utf-8')) as TextFile;
+	try {
+		const size = await file.getSize();
+		if (size > maxBytes) return null;
+		return await file.read(size);
+	} finally {
+		await file.close();
+	}
+}
+
 export async function writePodFile(
 	pod: BrowserPod,
 	absPath: string,

--- a/src/lib/pod/fs.ts
+++ b/src/lib/pod/fs.ts
@@ -21,7 +21,10 @@ export async function readPodFile(pod: BrowserPod, absPath: string): Promise<str
 }
 
 /** Reads a file as raw bytes so binary assets survive intact. */
-export async function readPodBinaryFile(pod: BrowserPod, absPath: string): Promise<Uint8Array> {
+export async function readPodBinaryFile(
+	pod: BrowserPod,
+	absPath: string
+): Promise<Uint8Array<ArrayBuffer>> {
 	const file = (await pod.openFile(absPath, 'binary')) as BinaryFile;
 	try {
 		const size = await file.getSize();

--- a/src/lib/pod/fs.ts
+++ b/src/lib/pod/fs.ts
@@ -1,3 +1,7 @@
+/**
+ * BrowserPod filesystem and terminal plumbing, shared by the playground IDE and the agent
+ * CLIs. Paths are absolute inside the pod; callers resolve them against their own workdir.
+ */
 import type { BinaryFile, BrowserPod, TextFile, Terminal } from '@leaningtech/browserpod';
 
 /** Default working directory. Curated templates hydrate here; GitHub clones live in a subdir. */

--- a/src/lib/pod/portals.ts
+++ b/src/lib/pod/portals.ts
@@ -1,0 +1,7 @@
+/**
+ * Portal events as BrowserPod reports them: a service came up (or went away) on a port.
+ *
+ * Owned by the pod layer because both boot paths (the playground IDE and the agent CLIs)
+ * produce these
+ */
+export type PortalUpdate = { port: number; url: string | null; active: boolean };

--- a/src/lib/stores/leaveWarning.svelte.ts
+++ b/src/lib/stores/leaveWarning.svelte.ts
@@ -4,20 +4,39 @@ export const leaveWarningState = $state<{ open: boolean; pendingPath: string }>(
 });
 
 // A `window.location.href` assignment triggers the browser's own `beforeunload` event just like
-// a refresh or a closed tab does. Pages that listen for it (to catch tab-close/refresh/back-
-// forward) call `consumeIntentionalNavigation()` there to skip their dialog for navigations we
-// triggered ourselves — the in-app leave-warning modal already asked, so a second native prompt
-// right after would just be a confusing duplicate.
+// a refresh or a closed tab does. `installLeaveGuard()` below consumes this flag to skip the
+// native prompt for navigations we triggered ourselves — the in-app leave-warning modal already
+// asked, so a second native prompt right after would just be a confusing duplicate.
 let intentionalNavigation = false;
 
 export function markIntentionalNavigation() {
 	intentionalNavigation = true;
 }
 
-export function consumeIntentionalNavigation(): boolean {
+function consumeIntentionalNavigation(): boolean {
 	const wasIntentional = intentionalNavigation;
 	intentionalNavigation = false;
 	return wasIntentional;
+}
+
+/**
+ * Installs the native unload prompt for a page with a live session, and returns a disposer.
+ * Only browsers get to show text here, and only their own generic wording; The custom
+ * "your work will be lost" copy is reserved for in-app navigation via the leave-warning modal.
+ * A `window.location.href` assignment fires this same event, so navigation we already
+ * confirmed in-app is marked "intentional" and skipped here to avoid a duplicate prompt.
+ * This only fires for real browser-driven unloads: tab close, refresh, back/forward, or a
+ * typed URL.
+ */
+export function installLeaveGuard(): () => void {
+	function handleBeforeUnload(event: BeforeUnloadEvent) {
+		if (consumeIntentionalNavigation()) return;
+		event.preventDefault();
+		event.returnValue = '';
+	}
+
+	window.addEventListener('beforeunload', handleBeforeUnload);
+	return () => window.removeEventListener('beforeunload', handleBeforeUnload);
 }
 
 /**

--- a/src/lib/stores/portals.svelte.ts
+++ b/src/lib/stores/portals.svelte.ts
@@ -3,6 +3,12 @@ import type { PortalUpdate } from '$lib/pod/portals';
 /** A live preview target as rendered by Portal.svelte's port selector. */
 export type PortalItem = { port: number; url: string };
 
+/**
+ * How far the preview frame has got with the selected portal. `waiting` keeps the iframe unmounted
+ * until the dev server answers, `loading` while its document arrives, `ready` once it has painted.
+ */
+export type FrameStatus = 'waiting' | 'loading' | 'ready';
+
 export type PortalStateOptions = {
 	/**
 	 * When it returns a port, only that port is auto-selected for the preview (frameworks with
@@ -27,12 +33,15 @@ export class PortalState {
 	selectedPort = $state<number | null>(null);
 	/** Preview URL of the selected portal; '' when none. */
 	url = $state('');
+	frameStatus = $state<FrameStatus>('waiting');
 	showMenu = $state(false);
 	showInfo = $state(false);
 	copied = $state(false);
 	qrError = $state('');
 
 	private copiedTimeout: ReturnType<typeof setTimeout> | undefined;
+	/** Fallback for a `load` that never fires. */
+	private frameReadyTimer: ReturnType<typeof setTimeout> | undefined;
 
 	constructor(private options: PortalStateOptions = {}) {}
 
@@ -48,10 +57,8 @@ export class PortalState {
 			this.portals = next;
 
 			const preferred = this.options.preferredPort?.();
-			if (preferred === undefined || update.port === preferred || this.selectedPort === null) {
-				this.selectedPort = update.port;
-				this.url = update.url;
-			}
+			if (preferred === undefined || update.port === preferred || this.selectedPort === null)
+				this.selectUrl(update.port, update.url);
 			this.options.onActivate?.(next.length);
 			return;
 		}
@@ -64,8 +71,7 @@ export class PortalState {
 			!next.some((item) => item.port === this.selectedPort)
 		) {
 			const fallback = next[0];
-			this.selectedPort = fallback?.port ?? null;
-			this.url = fallback?.url ?? '';
+			this.selectUrl(fallback?.port ?? null, fallback?.url ?? '');
 		}
 		if (next.length === 0) this.options.onEmpty?.();
 	};
@@ -74,10 +80,23 @@ export class PortalState {
 	onPortChange = (event: Event): void => {
 		const value = Number((event.currentTarget as HTMLSelectElement).value);
 		if (!Number.isInteger(value)) return;
-		this.selectedPort = value;
-		this.url = this.portals.find((item) => item.port === value)?.url ?? '';
+		this.selectUrl(value, this.portals.find((item) => item.port === value)?.url ?? '');
 		this.closeOverlays();
 	};
+
+	/**
+	 * Points the preview at a port. Unchanged URLs return early so a re-emitted portal does not
+	 * restart the wait.
+	 */
+	private selectUrl(port: number | null, url: string): void {
+		this.selectedPort = port;
+		if (url === this.url) return;
+		this.url = url;
+		// Unmount while waiting, so the frame re-navigates once this URL is ready.
+		this.frameStatus = 'waiting';
+		clearTimeout(this.frameReadyTimer);
+		if (url) void this.showFrameWhenServing(url);
+	}
 
 	toggleMenu = (): void => {
 		this.showMenu = !this.showMenu;
@@ -116,8 +135,51 @@ export class PortalState {
 		this.copiedTimeout = setTimeout(() => (this.copied = false), 1200);
 	};
 
-	/** Clears the copied-flash timer; call on host unmount. */
+	/** Reports that the framed document loaded. Ignored unless that frame is still the current one. */
+	reportFrameLoaded = (): void => {
+		if (this.frameStatus !== 'loading') return;
+		clearTimeout(this.frameReadyTimer);
+		this.frameStatus = 'ready';
+	};
+
+	/** Clears timers and stops any pending wait. */
 	dispose = (): void => {
 		clearTimeout(this.copiedTimeout);
+		clearTimeout(this.frameReadyTimer);
+		this.url = '';
+		this.frameStatus = 'waiting';
 	};
+
+	/** Polls until the dev server answers, then shows the frame. Shows it anyway once out of tries. */
+	private async showFrameWhenServing(url: string): Promise<void> {
+		for (let attempt = 0; attempt < PROBE_ATTEMPTS; attempt++) {
+			if (this.url !== url) return; // selection moved on
+			if (await serving(url)) break;
+			await new Promise((resolve) => setTimeout(resolve, PROBE_INTERVAL_MS));
+		}
+		if (this.url !== url) return;
+		this.frameStatus = 'loading';
+		// Advance anyway if `load` never fires, so the loader cannot stick.
+		this.frameReadyTimer = setTimeout(() => (this.frameStatus = 'ready'), FRAME_READY_DEADLINE_MS);
+	}
+}
+
+const PROBE_INTERVAL_MS = 1000;
+/** A real response takes under a second; a starting server holds the connection ~2.5min. */
+const PROBE_TIMEOUT_MS = 5000;
+const PROBE_ATTEMPTS = 60;
+const FRAME_READY_DEADLINE_MS = 8000;
+
+/** True once the dev server answers. Bounded: a starting server can accept and never reply. */
+async function serving(url: string): Promise<boolean> {
+	const abort = new AbortController();
+	const timer = setTimeout(() => abort.abort(), PROBE_TIMEOUT_MS);
+	try {
+		await fetch(url, { mode: 'no-cors', cache: 'no-store', signal: abort.signal });
+		return true;
+	} catch {
+		return false;
+	} finally {
+		clearTimeout(timer);
+	}
 }

--- a/src/lib/stores/portals.svelte.ts
+++ b/src/lib/stores/portals.svelte.ts
@@ -1,5 +1,4 @@
-/** A portal event from BrowserPod: a service came up (or went away) on a port. */
-export type PortalUpdate = { port: number; url: string | null; active: boolean };
+import type { PortalUpdate } from '$lib/pod/portals';
 
 /** A live preview target as rendered by Portal.svelte's port selector. */
 export type PortalItem = { port: number; url: string };

--- a/src/lib/stores/portals.svelte.ts
+++ b/src/lib/stores/portals.svelte.ts
@@ -96,6 +96,11 @@ export class PortalState {
 		this.showInfo = true;
 	};
 
+	/** Records what Portal.svelte's QR render reported; it owns the canvas, this owns the message. */
+	reportQrResult = (error: string | null): void => {
+		this.qrError = error ?? '';
+	};
+
 	openInNewTab = (): void => {
 		if (!this.url) return;
 		this.showMenu = false;

--- a/src/lib/stores/zen.svelte.ts
+++ b/src/lib/stores/zen.svelte.ts
@@ -1,0 +1,7 @@
+// Zen mode hides the global app chrome (Sidebar, UtilityBar, ribbon). Module-level $state
+// singleton (layout and IdeShell share it without prop threading).
+export const zenState = $state({ on: false });
+
+export function toggleZen() {
+	zenState.on = !zenState.on;
+}

--- a/src/lib/utils/bug-report.ts
+++ b/src/lib/utils/bug-report.ts
@@ -1,0 +1,62 @@
+/**
+ * Prefilled bug reports on github issue tracker.
+ */
+import podPkg from '@leaningtech/browserpod/package.json';
+import appPkg from '../../../package.json';
+
+/** Single destination for every bug report. */
+export const NEW_ISSUE_URL = 'https://github.com/leaningtech/browsercode/issues/new';
+
+export type BugReportContext = {
+	/** Repo the session cloned, as the session stored it; absent for framework templates. */
+	repo?: { url: string; ref: string } | null;
+	/** Live preview URL of the selected portal, when a dev server is up. */
+	previewUrl?: string | null;
+};
+
+/** New-issue URL prefilled with the failing project and the environment. */
+export function bugReportUrl(context: BugReportContext = {}): string {
+	const params = new URLSearchParams({ title: title(context), body: body(context) });
+	return `${NEW_ISSUE_URL}?${params}`;
+}
+
+function title({ repo }: BugReportContext): string {
+	return repo ? `IDE bug: ${repoSlug(repo.url)}` : 'IDE bug report';
+}
+
+/** `owner/repo` out of a GitHub URL; the URL itself if it does not look like one. */
+function repoSlug(url: string): string {
+	const [owner, name] = url.replace(/^https?:\/\/github\.com\//, '').split('/');
+	return owner && name ? `${owner}/${name}` : url;
+}
+
+/** Two labelled sections: where the bug happened, then what it happened on. */
+function body({ repo, previewUrl }: BugReportContext): string {
+	const where: string[] = [];
+	if (repo) where.push(`- **Repo:** ${repo.url} on \`${repo.ref}\``);
+	const page = typeof window === 'undefined' ? '' : window.location.href;
+	if (page) where.push(`- **Page:** ${page}`);
+	if (previewUrl) where.push(`- **Preview:** ${previewUrl}`);
+
+	const environment = [
+		`- **BrowserCode:** \`v${appPkg.version}\``,
+		`- **BrowserPod:** \`v${podPkg.version}\``
+	];
+	if (typeof navigator !== 'undefined')
+		environment.push(`- **Browser:** \`${navigator.userAgent}\``);
+
+	return [
+		'### What happened?',
+		'',
+		'<!-- What you expected, what happened instead, and the steps that got you there. -->',
+		'',
+		'### Session',
+		'',
+		...where,
+		'',
+		'### Environment',
+		'',
+		...environment,
+		''
+	].join('\n');
+}

--- a/src/lib/utils/main.ts
+++ b/src/lib/utils/main.ts
@@ -1,8 +1,8 @@
-import type { BinaryFile, BrowserPod } from '@leaningtech/browserpod';
+import type { BrowserPod } from '@leaningtech/browserpod';
 import { cliConfigs, toolItems } from '$lib/config/tools';
-import { writeToTerminal } from '$lib/ide/pod-fs';
+import { writePodBinaryFile, writeToTerminal } from '$lib/pod/fs';
 import { trackEvent } from './useLazyTracking';
-import type { PortalUpdate } from '$lib/stores/portals.svelte';
+import type { PortalUpdate } from '$lib/pod/portals';
 
 /**
  * Boots an agent tool's disk image into a pod and runs its CLI against the `#console`
@@ -64,7 +64,7 @@ export async function bootCLI(
 
 	if (config.projectFile) {
 		const filename = config.projectFile.split('/').pop()!;
-		await copyFile(pod, config.projectFile, homePath, filename);
+		await copyStaticFile(pod, config.projectFile, `${homePath}/${filename}`);
 	}
 
 	writeToTerminal(terminal, `Starting ${toolLabel}...\n`);
@@ -78,23 +78,11 @@ export async function bootCLI(
 	});
 }
 
-export async function copyFile(
-	pod: BrowserPod,
-	path: string,
-	prefix: string,
-	destFilename?: string
-) {
-	const normalizedPrefix = prefix.endsWith('/') ? prefix.slice(0, -1) : prefix;
-	const dest = destFilename ? `${normalizedPrefix}/${destFilename}` : `${normalizedPrefix}/${path}`;
-
-	const file = (await pod.createFile(dest, 'binary')) as BinaryFile;
-	const resp = await fetch(path);
-
-	if (!resp.ok) {
-		throw new Error(`Failed to fetch "${path}" (${resp.status} ${resp.statusText})`);
+/** Copies a static asset served by this app into the pod at `destPath`. */
+async function copyStaticFile(pod: BrowserPod, srcPath: string, destPath: string): Promise<void> {
+	const response = await fetch(srcPath);
+	if (!response.ok) {
+		throw new Error(`Failed to fetch "${srcPath}" (${response.status} ${response.statusText})`);
 	}
-
-	const buf = await resp.arrayBuffer();
-	await file.write(buf);
-	await file.close();
+	await writePodBinaryFile(pod, destPath, await response.arrayBuffer());
 }

--- a/src/lib/utils/main.ts
+++ b/src/lib/utils/main.ts
@@ -1,6 +1,7 @@
 import type { BrowserPod } from '@leaningtech/browserpod';
 import { cliConfigs, toolItems } from '$lib/config/tools';
 import { writePodBinaryFile, writeToTerminal } from '$lib/pod/fs';
+import { isIos } from './platform';
 import { trackEvent } from './useLazyTracking';
 import type { PortalUpdate } from '$lib/pod/portals';
 
@@ -20,11 +21,7 @@ export async function bootCLI(
 
 	const consoleElement = document.querySelector('#console') as HTMLElement;
 
-	const ua = navigator.userAgent;
-	const isIos =
-		/iPad|iPhone|iPod/.test(ua) ||
-		(navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
-	if (isIos) {
+	if (isIos()) {
 		consoleElement.textContent = 'unsupported';
 		return;
 	}

--- a/src/lib/utils/platform.ts
+++ b/src/lib/utils/platform.ts
@@ -1,0 +1,11 @@
+/**
+ * True on iOS, which BrowserPod does not support. iPadOS in desktop mode reports
+ * `MacIntel`, so touch points are checked too. Returns false without a `navigator`.
+ */
+export function isIos(): boolean {
+	if (typeof navigator === 'undefined') return false;
+	return (
+		/iPad|iPhone|iPod/.test(navigator.userAgent) ||
+		(navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1)
+	);
+}

--- a/src/lib/utils/viewport.ts
+++ b/src/lib/utils/viewport.ts
@@ -1,0 +1,15 @@
+const MOBILE_QUERY = '(max-width: 768px)';
+
+/**
+ * Calls `onChange` with the current viewport class, then again on every crossing of the mobile
+ * breakpoint; returns a disposer. Callers hold their own state, so a reaction to a crossing
+ * (collapsing a side panel, say) fires only on the crossing itself.
+ */
+export function watchIsMobile(onChange: (isMobile: boolean) => void): () => void {
+	const query = window.matchMedia(MOBILE_QUERY);
+	const handleChange = () => onChange(query.matches);
+
+	handleChange();
+	query.addEventListener('change', handleChange);
+	return () => query.removeEventListener('change', handleChange);
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -10,6 +10,7 @@
 	import { page } from '$app/stores';
 	import { toolItems } from '$lib/config/tools';
 	import { stepperState } from '$lib/stores/stepper.svelte';
+	import { zenState } from '$lib/stores/zen.svelte';
 
 	let { children } = $props();
 
@@ -20,10 +21,11 @@
 
 	// Show on the landing surfaces (Home, /agents, bare /ide) and during tour step 6.
 	let showRibbon = $derived(
-		ribbonAboveTour ||
-			$page.route.id === '/' ||
-			$page.route.id === '/agents' ||
-			($page.route.id === '/ide' && !$page.url.searchParams.has('framework'))
+		!zenState.on &&
+			(ribbonAboveTour ||
+				$page.route.id === '/' ||
+				$page.route.id === '/agents' ||
+				($page.route.id === '/ide' && !$page.url.searchParams.has('framework')))
 	);
 
 	const validToolIds = new Set<string>(toolItems.filter((t) => !t.disabled).map((t) => t.id));
@@ -74,6 +76,12 @@
 	<meta property="twitter:url" content={pageUrl} />
 </svelte:head>
 
+<svelte:window
+	onkeydown={(e) => {
+		if (zenState.on && e.key === 'Escape') zenState.on = false;
+	}}
+/>
+
 <IosUnsupportedModal />
 
 <div class="flex h-dvh w-screen overflow-hidden">
@@ -81,7 +89,9 @@
 	     Help flyout and the Home page both need to trigger it from anywhere via stepperState. -->
 	<Stepper />
 	<LeaveWarningModal />
-	<Sidebar />
+	{#if !zenState.on}
+		<Sidebar />
+	{/if}
 
 	<!-- GitHub Ribbon — landing surfaces only (Home, /agents, bare /ide — see showRibbon above);
 	     the sidebar carries the GitHub link on the app surfaces. -->
@@ -113,6 +123,8 @@
 			</main>
 		</div>
 
-		<UtilityBar />
+		{#if !zenState.on}
+			<UtilityBar />
+		{/if}
 	</div>
 </div>

--- a/src/routes/agents/[tool]/+page.svelte
+++ b/src/routes/agents/[tool]/+page.svelte
@@ -10,6 +10,7 @@
 	import { openTour } from '$lib/stores/stepper.svelte';
 	import { toolItems } from '$lib/config/tools';
 	import { requestSingleTabLock } from '$lib/utils/tabLock';
+	import { watchIsMobile } from '$lib/utils/viewport';
 	import { navigateWithLeaveGuard, installLeaveGuard } from '$lib/stores/leaveWarning.svelte';
 	import { PortalState } from '$lib/stores/portals.svelte';
 
@@ -114,14 +115,8 @@
 		showToolMenu = false;
 	}
 
-	function updateIsMobile() {
-		isMobile = window.matchMedia('(max-width: 768px)').matches;
-	}
-
 	onMount(() => {
-		updateIsMobile();
-		const mql = window.matchMedia('(max-width: 768px)');
-		mql.addEventListener('change', updateIsMobile);
+		const unwatchIsMobile = watchIsMobile((mobile) => (isMobile = mobile));
 		requestAnimationFrame(() => {
 			entered = true;
 		});
@@ -154,7 +149,7 @@
 		});
 
 		return () => {
-			mql.removeEventListener('change', updateIsMobile);
+			unwatchIsMobile();
 			disposeLeaveGuard();
 			portal.dispose();
 			releaseTabLock();

--- a/src/routes/agents/[tool]/+page.svelte
+++ b/src/routes/agents/[tool]/+page.svelte
@@ -15,9 +15,10 @@
 		consumeIntentionalNavigation
 	} from '$lib/stores/leaveWarning.svelte';
 	import { PortalState } from '$lib/stores/portals.svelte';
-	import type { PortalUpdate } from '$lib/pod/portals';
 
 	let isPortalVisible = true;
+	/** The div the pod's terminal attaches to, rendered by Terminal.svelte. */
+	let consoleEl: HTMLElement | null = null;
 
 	let portalFraction = 0.5;
 	let isDragging = false;
@@ -54,8 +55,8 @@
 	let activeMobileView: 'terminal' | 'preview' = 'terminal';
 
 	// Auto-show the preview on desktop, switch to it on mobile (first portal only), and hide
-	// the pane again when the last portal goes away — agents-specific; the IDE shell instead
-	// pins its preview to the framework's declared app port.
+	// the pane again when the last portal goes away; the IDE shell instead pins its preview
+	// to the framework's declared app port.
 	const portal = new PortalState({
 		onActivate: (count) => {
 			if (!isMobile) isPortalVisible = true;
@@ -77,14 +78,14 @@
 		showTerminalTip = false;
 	}
 
-	// Any keypress means they've already found the terminal — no need to keep the tip up.
+	// Any keypress means they've already found the terminal; no need to keep the tip up.
 	function handleAnyKeydown() {
 		if (showTerminalTip) dismissTerminalTip();
 	}
 
 	function attemptCloseTab() {
 		window.close();
-		// Browsers only let scripts close tabs they themselves opened — if we're still here
+		// Browsers only let scripts close tabs they themselves opened; If we're still here
 		// shortly after, that didn't work, so tell the user to close it manually instead.
 		setTimeout(() => {
 			closeFallback = true;
@@ -118,11 +119,11 @@
 		isMobile = window.matchMedia('(max-width: 768px)').matches;
 	}
 
-	// Only browsers get to show text here, and only their own generic wording — the custom
+	// Only browsers get to show text here, and only their own generic wording; The custom
 	// "your work will be lost" copy is reserved for in-app navigation via the leave-warning modal.
 	// A `window.location.href` assignment fires this same event, so navigation we already
-	// confirmed in-app is marked "intentional" and skipped here to avoid a duplicate prompt —
-	// this only fires for real browser-driven unloads: tab close, refresh, back/forward, or a
+	// confirmed in-app is marked "intentional" and skipped here to avoid a duplicate prompt.
+	// This only fires for real browser-driven unloads: tab close, refresh, back/forward, or a
 	// typed URL.
 	function handleBeforeUnload(event: BeforeUnloadEvent) {
 		if (consumeIntentionalNavigation()) return;
@@ -138,8 +139,8 @@
 			entered = true;
 		});
 
-		// Two tabs booting the same agent would both write to the same BrowserPod storage key —
-		// claim an exclusive, tab-lifetime lock first and only boot if we actually got it.
+		// Two tabs booting the same agent would both write to the same BrowserPod storage key;
+		// Claim an exclusive, tab-lifetime lock first and only boot if we actually got it.
 		const tool = getActiveTool();
 		const lock = requestSingleTabLock(`agent-session:${tool}`);
 		releaseTabLock = lock.release;
@@ -150,29 +151,19 @@
 				return;
 			}
 
-			// Only warn on tab close/refresh/back-button once a session is actually running here —
-			// the duplicate-tab case above has nothing booted, so there's no work to lose.
+			// Only warn on tab close/refresh/back-button once a session is actually running here;
+			// The duplicate-tab case above has nothing booted, so there's no work to lose.
 			window.addEventListener('beforeunload', handleBeforeUnload);
 
-			// Shown on every boot, not just the first ever visit — it's an easy thing to miss.
+			// Shown on every boot, not just the first ever visit.
 			showTerminalTip = true;
 
-			bootCLI((update: PortalUpdate | string) => {
-				if (typeof update === 'string') {
-					let parsed: URL;
-					try {
-						parsed = new URL(update);
-					} catch {
-						return;
-					}
-					const port = Number(parsed.port);
-					if (!Number.isInteger(port) || port <= 0) return;
-					portal.apply({ port, url: update, active: true });
-					return;
-				}
+			if (!consoleEl) {
+				console.error('Terminal container is not ready yet');
+				return;
+			}
 
-				portal.apply(update);
-			}, tool);
+			bootCLI(tool, consoleEl, portal.apply);
 		});
 
 		return () => {
@@ -230,7 +221,7 @@
 				class="absolute inset-0 bg-black"
 				class:hidden={isMobile && activeMobileView !== 'terminal'}
 			>
-				<Terminal />
+				<Terminal bind:consoleEl />
 			</div>
 
 			<!-- Non-blocking tip: this is a real terminal, not a GUI — clicks alone won't do much. -->

--- a/src/routes/agents/[tool]/+page.svelte
+++ b/src/routes/agents/[tool]/+page.svelte
@@ -287,6 +287,7 @@
 						onOpenNewTab={portal.openInNewTab}
 						onShowQrCode={portal.showQRCode}
 						onCloseOverlays={portal.closeOverlays}
+						onQrResult={portal.reportQrResult}
 					/>
 				</div>
 			{:else if isMobile && portal.portals.length > 0 && activeMobileView === 'preview'}
@@ -306,6 +307,7 @@
 						onOpenNewTab={portal.openInNewTab}
 						onShowQrCode={portal.showQRCode}
 						onCloseOverlays={portal.closeOverlays}
+						onQrResult={portal.reportQrResult}
 					/>
 				</div>
 			{/if}

--- a/src/routes/agents/[tool]/+page.svelte
+++ b/src/routes/agents/[tool]/+page.svelte
@@ -13,6 +13,8 @@
 	import { watchIsMobile } from '$lib/utils/viewport';
 	import { navigateWithLeaveGuard, installLeaveGuard } from '$lib/stores/leaveWarning.svelte';
 	import { PortalState } from '$lib/stores/portals.svelte';
+	import ZenToggle from '$lib/components/ZenToggle.svelte';
+	import { zenState } from '$lib/stores/zen.svelte';
 
 	let isPortalVisible = $state(true);
 	/** The div the pod's terminal attaches to, rendered by Terminal.svelte. */
@@ -149,6 +151,8 @@
 		});
 
 		return () => {
+			// Never leave the global chrome hidden after navigating away from an agent session.
+			zenState.on = false;
 			unwatchIsMobile();
 			disposeLeaveGuard();
 			portal.dispose();
@@ -205,6 +209,16 @@
 			>
 				<Terminal bind:consoleEl />
 			</div>
+
+			<!-- Zen toggle: the agents view has no icon rail, so this floating control is the
+			     always-visible way in and out. Desktop only. -->
+			{#if !isMobile}
+				<ZenToggle
+					baseClass="absolute bottom-4 left-4 z-30 flex items-center justify-center rounded-lg border p-2 backdrop-blur-sm transition"
+					activeClass="border-bc-azure/40 bg-bc-azure/20 text-bc-azure"
+					idleClass="border-white/10 bg-black/40 text-white/40 hover:bg-black/60 hover:text-white/70"
+				/>
+			{/if}
 
 			<!-- Non-blocking tip: this is a real terminal, not a GUI — clicks alone won't do much. -->
 			{#if showTerminalTip && !(isMobile && activeMobileView !== 'terminal')}

--- a/src/routes/agents/[tool]/+page.svelte
+++ b/src/routes/agents/[tool]/+page.svelte
@@ -14,7 +14,8 @@
 		navigateWithLeaveGuard,
 		consumeIntentionalNavigation
 	} from '$lib/stores/leaveWarning.svelte';
-	import { PortalState, type PortalUpdate } from '$lib/stores/portals.svelte';
+	import { PortalState } from '$lib/stores/portals.svelte';
+	import type { PortalUpdate } from '$lib/pod/portals';
 
 	let isPortalVisible = true;
 

--- a/src/routes/agents/[tool]/+page.svelte
+++ b/src/routes/agents/[tool]/+page.svelte
@@ -16,13 +16,13 @@
 	} from '$lib/stores/leaveWarning.svelte';
 	import { PortalState } from '$lib/stores/portals.svelte';
 
-	let isPortalVisible = true;
+	let isPortalVisible = $state(true);
 	/** The div the pod's terminal attaches to, rendered by Terminal.svelte. */
-	let consoleEl: HTMLElement | null = null;
+	let consoleEl = $state<HTMLElement | null>(null);
 
-	let portalFraction = 0.5;
-	let isDragging = false;
-	let containerEl: HTMLElement | null = null;
+	let portalFraction = $state(0.5);
+	let isDragging = $state(false);
+	let containerEl = $state<HTMLElement | null>(null);
 
 	function startDrag(e: MouseEvent) {
 		e.preventDefault();
@@ -51,8 +51,8 @@
 		window.addEventListener('mouseup', onUp);
 	}
 
-	let isMobile = false;
-	let activeMobileView: 'terminal' | 'preview' = 'terminal';
+	let isMobile = $state(false);
+	let activeMobileView = $state<'terminal' | 'preview'>('terminal');
 
 	// Auto-show the preview on desktop, switch to it on mobile (first portal only), and hide
 	// the pane again when the last portal goes away; the IDE shell instead pins its preview
@@ -64,15 +64,16 @@
 		},
 		onEmpty: () => (isPortalVisible = false)
 	});
-	let showToolMenu = false;
-	let showDuplicateTabWarning = false;
-	let closeFallback = false;
+	let showToolMenu = $state(false);
+	let showDuplicateTabWarning = $state(false);
+	let closeFallback = $state(false);
+	// Deliberately not state: assigned once at boot and only called from the unmount cleanup.
 	let releaseTabLock: () => void = () => {};
-	let showTerminalTip = false;
+	let showTerminalTip = $state(false);
 
 	// Same reveal treatment as the landing page's About panel: starts closed so the transition
 	// actually animates in on arrival, rather than snapping straight to open.
-	let entered = false;
+	let entered = $state(false);
 
 	function dismissTerminalTip() {
 		showTerminalTip = false;

--- a/src/routes/agents/[tool]/+page.svelte
+++ b/src/routes/agents/[tool]/+page.svelte
@@ -270,6 +270,8 @@
 				>
 					<Portal
 						src={portal.url}
+						frameStatus={portal.frameStatus}
+						onFrameLoad={portal.reportFrameLoaded}
 						portals={portal.portals}
 						selectedPort={portal.selectedPort}
 						showMenu={portal.showMenu}
@@ -290,6 +292,8 @@
 				<div class="absolute inset-0 overflow-hidden">
 					<Portal
 						src={portal.url}
+						frameStatus={portal.frameStatus}
+						onFrameLoad={portal.reportFrameLoaded}
 						portals={portal.portals}
 						selectedPort={portal.selectedPort}
 						showMenu={portal.showMenu}

--- a/src/routes/agents/[tool]/+page.svelte
+++ b/src/routes/agents/[tool]/+page.svelte
@@ -6,7 +6,7 @@
 
 	import { onMount } from 'svelte';
 	import { page } from '$app/stores';
-	import { bootCLI } from '$lib/utils/main';
+	import { bootCLI } from '$lib/agents/boot';
 	import { openTour } from '$lib/stores/stepper.svelte';
 	import { toolItems } from '$lib/config/tools';
 	import { requestSingleTabLock } from '$lib/utils/tabLock';

--- a/src/routes/agents/[tool]/+page.svelte
+++ b/src/routes/agents/[tool]/+page.svelte
@@ -10,10 +10,7 @@
 	import { openTour } from '$lib/stores/stepper.svelte';
 	import { toolItems } from '$lib/config/tools';
 	import { requestSingleTabLock } from '$lib/utils/tabLock';
-	import {
-		navigateWithLeaveGuard,
-		consumeIntentionalNavigation
-	} from '$lib/stores/leaveWarning.svelte';
+	import { navigateWithLeaveGuard, installLeaveGuard } from '$lib/stores/leaveWarning.svelte';
 	import { PortalState } from '$lib/stores/portals.svelte';
 
 	let isPortalVisible = $state(true);
@@ -69,6 +66,7 @@
 	let closeFallback = $state(false);
 	// Deliberately not state: assigned once at boot and only called from the unmount cleanup.
 	let releaseTabLock: () => void = () => {};
+	let disposeLeaveGuard: () => void = () => {};
 	let showTerminalTip = $state(false);
 
 	// Same reveal treatment as the landing page's About panel: starts closed so the transition
@@ -120,18 +118,6 @@
 		isMobile = window.matchMedia('(max-width: 768px)').matches;
 	}
 
-	// Only browsers get to show text here, and only their own generic wording; The custom
-	// "your work will be lost" copy is reserved for in-app navigation via the leave-warning modal.
-	// A `window.location.href` assignment fires this same event, so navigation we already
-	// confirmed in-app is marked "intentional" and skipped here to avoid a duplicate prompt.
-	// This only fires for real browser-driven unloads: tab close, refresh, back/forward, or a
-	// typed URL.
-	function handleBeforeUnload(event: BeforeUnloadEvent) {
-		if (consumeIntentionalNavigation()) return;
-		event.preventDefault();
-		event.returnValue = '';
-	}
-
 	onMount(() => {
 		updateIsMobile();
 		const mql = window.matchMedia('(max-width: 768px)');
@@ -154,7 +140,7 @@
 
 			// Only warn on tab close/refresh/back-button once a session is actually running here;
 			// The duplicate-tab case above has nothing booted, so there's no work to lose.
-			window.addEventListener('beforeunload', handleBeforeUnload);
+			disposeLeaveGuard = installLeaveGuard();
 
 			// Shown on every boot, not just the first ever visit.
 			showTerminalTip = true;
@@ -169,7 +155,7 @@
 
 		return () => {
 			mql.removeEventListener('change', updateIsMobile);
-			window.removeEventListener('beforeunload', handleBeforeUnload);
+			disposeLeaveGuard();
 			portal.dispose();
 			releaseTabLock();
 		};

--- a/src/routes/ide/github/[owner]/[repo]/tree/[ref]/[...dir]/+page.svelte
+++ b/src/routes/ide/github/[owner]/[repo]/tree/[ref]/[...dir]/+page.svelte
@@ -4,8 +4,7 @@
 	import Icon from '@iconify/svelte';
 	import IdeShell from '$lib/components/ide/IdeShell.svelte';
 	import { IdeSession, type PortalUpdate } from '$lib/ide/session.svelte';
-
-	const SEGMENT = /^[\w.-]+$/;
+	import { isValidRepoPath } from '$lib/github/parse';
 
 	// `[...dir]` matches the empty segment, so /…/tree/<ref> arrives here with dir = ''.
 	const owner = $page.params.owner ?? '';
@@ -13,12 +12,7 @@
 	const ref = $page.params.ref ?? '';
 	const dir = $page.params.dir ?? '';
 
-	function dirIsValid(value: string): boolean {
-		if (value === '') return true;
-		return value.split('/').every((seg) => SEGMENT.test(seg) && seg !== '..');
-	}
-
-	const valid = SEGMENT.test(owner) && SEGMENT.test(repo) && SEGMENT.test(ref) && dirIsValid(dir);
+	const valid = isValidRepoPath({ owner, repo, ref, dir });
 
 	const session = new IdeSession();
 


### PR DESCRIPTION
The playground now boots from a GitHub repo as well. A new `/ide/github/[owner]/[repo]/tree/[ref]/[...dir]` route shallow-clones a public repo into a fresh pod, installs it, and resolves its dev script. Access is unauthenticated: public repos only, 60 req/hr, and clones don't persist.

Three larger features come with it:  zen mode, a file search panel over the pod's working tree, and project download as a zip.

The rest is refactoring, kept as separate commits deliberately. One bit commit would be harder to review and separate.
 
Still open is a last UI/UX pass. The clone-from-GitHub section and the download button's position both need another look. The native to WASM dependency-override swap is also shelved out of this branch for now. Both the override format and how they're applied need rethinking.